### PR TITLE
fix: null device ID error

### DIFF
--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -938,7 +938,7 @@ type Developer {
 
 type Device {
   "The device ID"
-  id: ID!
+  id: ID
 
   "If this device is the currently active device."
   isActive: Boolean!


### PR DESCRIPTION
This is seriously the coolest demo I've ever cloned + run 😎 This is a 1 line fix for an interesting issue I ran into when setting up the project for the first time.

The instructions were all super easy to follow: got my Spotify app set up, plugged in my env vars and started the client + server. Super slick. After running the app, I saw:

## Before
![CleanShot 2023-02-01 at 15 01 01](https://user-images.githubusercontent.com/5139846/216151265-26b629bc-afae-465b-a989-17b2f946848e.png)

With a console error about the non-nullable field `Device.id` being null.

Poked around and realized commenting out `<PlaybackStateSubscriber />` fixed it. Then saw that with the call to `/me/player`, the Spotify API was indeed returning a null device id!

![CleanShot 2023-02-01 at 15 00 38](https://user-images.githubusercontent.com/5139846/216151684-913b219c-9968-476f-a2be-e557c4527aea.png)

Not sure why my living room Sonos has a null device ID but there you have it 😅 Also learned in realtime that my kid is listening to "5 Little Speckled Frogs" as I work from a cafe... If he wasn't listening to music I don't think I would have hit this edge case! (Maybe a Sonos <> Spotify integration bug?)

## After
![CleanShot 2023-02-01 at 15 00 21](https://user-images.githubusercontent.com/5139846/216152101-ca39e37f-6713-4901-b490-eca7db725f0f.png)
