### PR TITLE
Temporarily revert changes to work with federation

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,7 +3,9 @@ import './env';
 import { ApolloServer } from '@apollo/server';
 import { expressMiddleware } from '@apollo/server/express4';
 import { ApolloServerPluginDrainHttpServer } from '@apollo/server/plugin/drainHttpServer';
-import { buildSubgraphSchema } from '@apollo/subgraph';
+// TODO: Add me back when @apollo/subgraph adds subscription support
+// https://github.com/apollographql/graphos-subscriptions/issues/123
+// import { buildSubgraphSchema } from '@apollo/subgraph';
 import { PubSub } from 'graphql-subscriptions';
 import { WebSocketServer } from 'ws';
 import { useServer } from 'graphql-ws/lib/use/ws';
@@ -21,8 +23,11 @@ import Publisher from './publisher';
 import { readEnv } from './utils/env';
 import { ContextValue } from './types';
 import { TOPICS } from './constants';
+// TODO: Remove me when @apollo/subgraph adds subscription support
+// https://github.com/apollographql/graphos-subscriptions/issues/123
+import { makeExecutableSchema } from '@graphql-tools/schema';
 
-const schema = buildSubgraphSchema({ typeDefs, resolvers });
+const schema = makeExecutableSchema({ typeDefs, resolvers });
 
 const app = express();
 const httpServer = http.createServer(app);

--- a/server/src/resolvers/Album.ts
+++ b/server/src/resolvers/Album.ts
@@ -16,9 +16,11 @@ const resolvers: AlbumResolvers = {
       offset: args.offset ?? undefined,
     });
   },
-  __resolveReference: (album, { dataSources }) => {
-    return dataSources.spotify.getAlbum(album.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (album, { dataSources }) => {
+  //   return dataSources.spotify.getAlbum(album.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/Artist.ts
+++ b/server/src/resolvers/Artist.ts
@@ -24,9 +24,11 @@ const resolvers: ArtistResolvers = {
 
     return tracks;
   },
-  __resolveReference: (artist, { dataSources }) => {
-    return dataSources.spotify.getArtist(artist.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (artist, { dataSources }) => {
+  //   return dataSources.spotify.getArtist(artist.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/Episode.ts
+++ b/server/src/resolvers/Episode.ts
@@ -12,9 +12,11 @@ const resolvers: EpisodeResolvers = {
   isPlayable: prop('is_playable'),
   releaseDate: itself(),
   resumePoint: prop('resume_point'),
-  __resolveReference: (episode, { dataSources }) => {
-    return dataSources.spotify.getEpisode(episode.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (episode, { dataSources }) => {
+  //   return dataSources.spotify.getEpisode(episode.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/Playlist.ts
+++ b/server/src/resolvers/Playlist.ts
@@ -19,9 +19,11 @@ const resolvers: PlaylistResolvers = {
       items: playlistTracks.items.filter((item) => item.track),
     };
   },
-  __resolveReference: (playlist, { dataSources }) => {
-    return dataSources.spotify.getPlaylist(playlist.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (playlist, { dataSources }) => {
+  //   return dataSources.spotify.getPlaylist(playlist.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/Show.ts
+++ b/server/src/resolvers/Show.ts
@@ -14,9 +14,11 @@ const resolvers: ShowResolvers = {
   externalUrls: prop('external_urls'),
   isExternallyHosted: prop('is_externally_hosted'),
   mediaType: prop('media_type'),
-  __resolveReference: (show, { dataSources }) => {
-    return dataSources.spotify.getShow(show.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (show, { dataSources }) => {
+  //   return dataSources.spotify.getShow(show.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/Track.ts
+++ b/server/src/resolvers/Track.ts
@@ -36,9 +36,11 @@ const resolvers: TrackResolvers = {
     is_playable === undefined ? true : is_playable,
   previewUrl: prop('preview_url'),
   trackNumber: prop('track_number'),
-  __resolveReference: (track, { dataSources }) => {
-    return dataSources.spotify.getTrack(track.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (track, { dataSources }) => {
+  //   return dataSources.spotify.getTrack(track.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/User.ts
+++ b/server/src/resolvers/User.ts
@@ -4,9 +4,11 @@ import { prop } from './helpers';
 const resolvers: UserResolvers = {
   displayName: prop('display_name'),
   externalUrls: prop('external_urls'),
-  __resolveReference: (user, { dataSources }) => {
-    return dataSources.spotify.getUser(user.id);
-  },
+  // TODO: Add back when @apollo/subgraph adds subscription support
+  // https://github.com/apollographql/graphos-subscriptions/issues/123
+  // __resolveReference: (user, { dataSources }) => {
+  //   return dataSources.spotify.getUser(user.id);
+  // },
 };
 
 export default resolvers;

--- a/server/src/resolvers/types.ts
+++ b/server/src/resolvers/types.ts
@@ -2275,17 +2275,6 @@ export type ResolversObject<TObject> = WithIndex<TObject>;
 
 export type ResolverTypeWrapper<T> = Promise<T> | T;
 
-export type ReferenceResolver<TResult, TReference, TContext> = (
-      reference: TReference,
-      context: TContext,
-      info: GraphQLResolveInfo
-    ) => Promise<TResult> | TResult;
-
-      type ScalarCheck<T, S> = S extends true ? T : NullableCheck<T, S>;
-      type NullableCheck<T, S> = Maybe<T> extends T ? Maybe<ListCheck<NonNullable<T>, S>> : ListCheck<T, S>;
-      type ListCheck<T, S> = T extends (infer U)[] ? NullableCheck<U, S>[] : GraphQLRecursivePick<T, S>;
-      export type GraphQLRecursivePick<T, S> = { [K in keyof T & keyof S]: ScalarCheck<T[K], S[K]> };
-    
 export type Resolver<TResult, TParent = {}, TContext = {}, TArgs = {}> = ResolverFn<TResult, TParent, TContext, TArgs>;
 
 export type ResolverFn<TResult, TParent, TContext, TArgs> = (
@@ -2681,7 +2670,6 @@ export type AddItemsToPlaylistPayloadResolvers<ContextType = ContextValue, Paren
 }>;
 
 export type AlbumResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Album'] = ResolversParentTypes['Album']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Album']>, { __typename: 'Album' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   albumType?: Resolver<ResolversTypes['AlbumType'], ParentType, ContextType>;
   artists?: Resolver<Array<ResolversTypes['Artist']>, ParentType, ContextType>;
   copyrights?: Resolver<Array<ResolversTypes['Copyright']>, ParentType, ContextType>;
@@ -2715,7 +2703,6 @@ export type AlbumTrackEdgeResolvers<ContextType = ContextValue, ParentType exten
 export type AlbumTypeResolvers = { ALBUM: 'album', COMPILATION: 'compilation', SINGLE: 'single' };
 
 export type ArtistResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Artist'] = ResolversParentTypes['Artist']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Artist']>, { __typename: 'Artist' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   albums?: Resolver<Maybe<ResolversTypes['ArtistAlbumsConnection']>, ParentType, ContextType, Partial<ArtistAlbumsArgs>>;
   externalUrls?: Resolver<ResolversTypes['ExternalUrl'], ParentType, ContextType>;
   followers?: Resolver<ResolversTypes['Followers'], ParentType, ContextType>;
@@ -2815,7 +2802,6 @@ export type DeviceResolvers<ContextType = ContextValue, ParentType extends Resol
 }>;
 
 export type EpisodeResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Episode'] = ResolversParentTypes['Episode']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Episode']>, { __typename: 'Episode' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   audioPreviewUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType, RequireFields<EpisodeDescriptionArgs, 'format'>>;
   durationMs?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
@@ -2993,7 +2979,6 @@ export type PlayerResolvers<ContextType = ContextValue, ParentType extends Resol
 }>;
 
 export type PlaylistResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Playlist'] = ResolversParentTypes['Playlist']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Playlist']>, { __typename: 'Playlist' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   collaborative?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   externalUrls?: Resolver<ResolversTypes['ExternalUrl'], ParentType, ContextType>;
@@ -3289,7 +3274,6 @@ export type SetVolumeResponseResolvers<ContextType = ContextValue, ParentType ex
 }>;
 
 export type ShowResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Show'] = ResolversParentTypes['Show']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Show']>, { __typename: 'Show' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   description?: Resolver<ResolversTypes['String'], ParentType, ContextType, RequireFields<ShowDescriptionArgs, 'format'>>;
   episodes?: Resolver<Maybe<ResolversTypes['ShowEpisodesConnection']>, ParentType, ContextType, Partial<ShowEpisodesArgs>>;
   explicit?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -3365,7 +3349,6 @@ export type TopTracksConnectionResolvers<ContextType = ContextValue, ParentType 
 }>;
 
 export type TrackResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['Track'] = ResolversParentTypes['Track']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['Track']>, { __typename: 'Track' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   album?: Resolver<ResolversTypes['Album'], ParentType, ContextType>;
   artists?: Resolver<Array<ResolversTypes['Artist']>, ParentType, ContextType>;
   audioFeatures?: Resolver<Maybe<ResolversTypes['TrackAudioFeatures']>, ParentType, ContextType>;
@@ -3425,7 +3408,6 @@ export type UpdateFieldConfigPayloadResolvers<ContextType = ContextValue, Parent
 }>;
 
 export type UserResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = ResolversObject<{
-  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['User']>, { __typename: 'User' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
   displayName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   externalUrls?: Resolver<ResolversTypes['ExternalUrl'], ParentType, ContextType>;
   followers?: Resolver<ResolversTypes['Followers'], ParentType, ContextType>;

--- a/server/src/schema.graphql
+++ b/server/src/schema.graphql
@@ -478,7 +478,7 @@ type AddItemsToPlaylistPayload {
 }
 
 "Spotify catalog information for an album."
-type Album @key(fields:"id") {
+type Album { # @key(fields: "id")
   "The type of the album."
   albumType: AlbumType!
 
@@ -584,7 +584,7 @@ enum AlbumType {
 """
 Spotify catalog information for an artist.
 """
-type Artist @key(fields:"id") {
+type Artist { # @key(fields: "id")
   """
   Spotify catalog information about an artist's albums.
   """
@@ -973,7 +973,7 @@ type Device {
 }
 
 "Spotify catalog information for an episode."
-type Episode implements PlaylistTrack & PlaybackItem @key(fields:"id") {
+type Episode implements PlaylistTrack & PlaybackItem { # @key(fields: "id")
   """
   The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the episode.
   """
@@ -1399,7 +1399,7 @@ type Player {
 }
 
 "Information about a playlist owned by a Spotify user"
-type Playlist @key(fields:"id") {
+type Playlist { # @key(fields:"id")
   """
   The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids)
   for the playlist.
@@ -1718,7 +1718,7 @@ enum RepeatMode {
 }
 
 "Spotify catalog information for a show."
-type Show @key(fields:"id") {
+type Show { # @key(fields: "id")
   "A description of the show."
   description(format: TextFormat = PLAIN): String!
 
@@ -1819,7 +1819,7 @@ enum TextFormat {
 }
 
 "Spotify catalog information for a track."
-type Track implements PlaylistTrack & PlaybackItem @key(fields:"id") {
+type Track implements PlaylistTrack & PlaybackItem { # @key(fields: "id")
   """
   The [Spotify ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for the track.
   """
@@ -2023,7 +2023,7 @@ type TrackExternalIds {
 }
 
 "Public profile information about a Spotify user."
-type User @key(fields:"id") {
+type User { # @key(fields: "id")
   """
   The [Spotify user ID](https://developer.spotify.com/documentation/web-api/#spotify-uris-and-ids) for this user.
   """


### PR DESCRIPTION
Unfortunately `@apollo/subgraph` doesn't yet support subscriptions, so trying to use it to handle playback state is broken. This PR "reverts" some of that work by using the old way of spinning up the server and commenting out the relevant code added from https://github.com/jerelmiller/react-apollo-spotify-demo/pull/3. Once subscription support is added, we can undo the changes from this PR.
