### PR TITLE
Better subscription error handling

### DIFF
--- a/server/src/dataSources/spotify.ts
+++ b/server/src/dataSources/spotify.ts
@@ -590,9 +590,10 @@ export default class SpotifyAPI extends RESTDataSource {
     response: FetcherResponse;
     parsedBody: Spotify.Error.RegularError;
   }) {
-    const { error } = parsedBody;
+    const error =
+      typeof parsedBody === 'string' ? parsedBody : parsedBody.error;
 
-    return new GraphQLError(error.message, {
+    return new GraphQLError(typeof error === 'string' ? error : error.message, {
       extensions: {
         code: this.getCodeFromStatus(response),
         reason: error.reason,

--- a/server/src/publisher.ts
+++ b/server/src/publisher.ts
@@ -19,7 +19,13 @@ export default class Publisher {
     playbackState: Spotify.Object.PlaybackState | null;
   }) {
     this.pubsub.publish(TOPICS.PLAYBACK_STATE_CHANGED, {
-      playbackStateChanged: playbackState,
+      data: {
+        playbackStateChanged: playbackState,
+      },
     });
+  }
+
+  playbackStateError(error: Error) {
+    this.pubsub.publish(TOPICS.PLAYBACK_STATE_CHANGED, { error });
   }
 }


### PR DESCRIPTION
When an error occurs in the subscription, its swallowed by the existing implementation. This PR adds a `resolver` function and allows for the publishing of errors to the subscription so that we can properly send those to the client.