### PR TITLE
Add a new error page for routes not yet implemented and add helpful contributing guidelines

### DIFF
--- a/client/src/components/RootErrorBoundary.tsx
+++ b/client/src/components/RootErrorBoundary.tsx
@@ -2,15 +2,17 @@ import { ApolloError } from '@apollo/client';
 import {
   useRouteError,
   isRouteErrorResponse,
+  Location,
   Navigate,
   Link,
   useLocation,
+  matchPath,
 } from 'react-router-dom';
 import ErrorTitle from './ErrorTitle';
 import ErrorDescription from './ErrorDescription';
 import ErrorActionLink from './ErrorActionLink';
 import Layout from './Layout';
-import { DEFAULT_BACKGROUND_COLOR } from '../constants';
+import { DEFAULT_BACKGROUND_COLOR, NOT_IMPLEMENTED_ROUTES } from '../constants';
 import useSetBackgroundColor from '../hooks/useSetBackgroundColor';
 
 const didBecomeUnauthenticated = (error: unknown) => {
@@ -28,6 +30,12 @@ const didBecomeUnauthenticated = (error: unknown) => {
   }
 
   return false;
+};
+
+const matchesNotImplementedRoute = (location: Location) => {
+  return NOT_IMPLEMENTED_ROUTES.some((path) => {
+    return matchPath(path, location.pathname);
+  });
 };
 
 const RootErrorBoundary = () => {
@@ -52,8 +60,34 @@ interface ErrorBodyProps {
 
 const ErrorBody = ({ error }: ErrorBodyProps) => {
   const location = useLocation();
+  const isNotFoundError = isRouteErrorResponse(error) && error.status === 404;
 
-  if (isRouteErrorResponse(error) && error.status === 404) {
+  if (isNotFoundError && matchesNotImplementedRoute(location)) {
+    return (
+      <>
+        <ErrorTitle>Page not implemented</ErrorTitle>
+        <ErrorDescription>
+          We'd really ❤️ for this page to exist, but it's not yet been
+          implemented 💔.
+        </ErrorDescription>
+        <ErrorActionLink to="/">Go home</ErrorActionLink>
+        <p className="text-sm mt-8 text-center max-w-lg">
+          Want to implement it yourself? Check out our{' '}
+          <a
+            href="http://github.com/apollographql/spotify-showcase/issues"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            issues
+          </a>{' '}
+          for more details and send us a pull request!
+        </p>
+      </>
+    );
+  }
+
+  if (isNotFoundError) {
     return (
       <>
         <ErrorTitle>Page not found</ErrorTitle>

--- a/client/src/components/RootErrorBoundary.tsx
+++ b/client/src/components/RootErrorBoundary.tsx
@@ -111,12 +111,25 @@ const ErrorBody = ({ error }: ErrorBodyProps) => {
         <a className="underline" href={location.pathname}>
           reloading the page
         </a>
-        , otherwise you may go{' '}
+        , otherwise go back{' '}
         <Link to="/" className="underline">
-          back home
+          home
         </Link>
         .
       </ErrorDescription>
+      <p className="text-sm mt-4 text-center max-w-lg">
+        Does this seem like a bug 🐛? Open an{' '}
+        <a
+          href="http://github.com/apollographql/spotify-showcase/issues"
+          target="_blank"
+          rel="noreferrer"
+          className="underline"
+        >
+          issue
+        </a>{' '}
+        to let us know you've encountered something unexpected, or send us a
+        pull request!
+      </p>
     </>
   );
 };

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -12,3 +12,9 @@ export const NOTIFICATION = {
   SAVED_TRACK: 'Added to your Liked Songs',
   SAVED_TRACK_ERROR: 'Could not save to your Liked Songs',
 } as const;
+
+export const NOT_IMPLEMENTED_ROUTES = [
+  '/search',
+  '/users/:id',
+  '/collection/episodes',
+];


### PR DESCRIPTION
Add some helpful contributing guidelines to some error pages. Add a new error page for not implemented pages to be more helpful.

<img width="1512" alt="Screenshot 2023-03-07 at 5 54 29 PM" src="https://user-images.githubusercontent.com/565661/223592181-9200ff55-e9b9-4f8f-aad4-24496e1b6726.png">
<img width="1512" alt="Screenshot 2023-03-07 at 5 58 50 PM" src="https://user-images.githubusercontent.com/565661/223592183-a248719c-6fdf-4d24-9a4a-9dbb6107638a.png">
