### PR TITLE
Remove `suspensePolicy` in favor of `startTransition` and `useDeferredValue`

### DIFF
--- a/client/src/components/LikeControl.tsx
+++ b/client/src/components/LikeControl.tsx
@@ -10,6 +10,7 @@ import {
 import LikeButton, { LikeButtonProps } from './LikeButton';
 import useSaveTracksMutation from '../mutations/useSaveTracksMutation';
 import useRemoveTracksMutation from '../mutations/useRemoveSavedTracksMutation';
+import { useDeferredValue } from 'react';
 
 interface LikeControlProps {
   className?: LikeButtonProps['className'];
@@ -27,21 +28,22 @@ const LIKE_CONTROL_QUERY = gql`
 `;
 
 const LikeControl = ({ className, playbackItem, size }: LikeControlProps) => {
+  const deferredId = useDeferredValue(playbackItem?.id);
+
   const { data } = useSuspenseQuery<
     LikeControlQuery,
     LikeControlQueryVariables
   >(LIKE_CONTROL_QUERY, {
     errorPolicy: 'ignore',
-    suspensePolicy: 'initial',
     variables: {
-      ids: [playbackItem?.id].filter(Boolean),
+      ids: [deferredId].filter(Boolean),
     },
   });
 
   const [saveTracks] = useSaveTracksMutation();
   const [removeTracks] = useRemoveTracksMutation();
 
-  if (!data.me) {
+  if (!data?.me) {
     throw new Response('You must be logged in', { status: 401 });
   }
 

--- a/client/src/hooks/useOffsetBasedPaginationObserver.ts
+++ b/client/src/hooks/useOffsetBasedPaginationObserver.ts
@@ -1,4 +1,4 @@
-import { RefObject, useRef } from 'react';
+import { RefObject, useRef, startTransition } from 'react';
 import useIntersectionObserver from './useIntersectionObserver';
 import useScrollContainer from './useScrollContainer';
 
@@ -37,11 +37,13 @@ const useOffsetBasedPaginationObserver = (
       if (isIntersecting && pageInfo?.hasNextPage && !isLoadingRef.current) {
         const { offset, limit } = pageInfo;
 
-        isLoadingRef.current = true;
+        startTransition(() => {
+          isLoadingRef.current = true;
 
-        await fetchMore({ variables: { offset: offset + limit } });
-
-        isLoadingRef.current = false;
+          fetchMore({ variables: { offset: offset + limit } }).then(() => {
+            isLoadingRef.current = false;
+          });
+        });
       }
     }
   );

--- a/client/src/hooks/useSavedTracksContains.ts
+++ b/client/src/hooks/useSavedTracksContains.ts
@@ -60,7 +60,6 @@ const useSavedTracksContains = (ids: string[]) => {
   // queries loaded in useEffect.
   useSuspenseQuery(SAVED_TRACKS_CONTAINS_QUERY, {
     errorPolicy: 'ignore',
-    suspensePolicy: 'initial',
     variables: { ids: ids.slice(0, INITIAL_BATCH_COUNT) },
   });
 

--- a/client/src/routes/collection/albums.tsx
+++ b/client/src/routes/collection/albums.tsx
@@ -38,7 +38,6 @@ export const RouteComponent = () => {
     CollectionAlbumsRouteQuery,
     CollectionAlbumsRouteQueryVariables
   >(COLLECTION_ALBUMS_ROUTE_QUERY, {
-    suspensePolicy: 'initial',
     variables: { limit: 50 },
   });
 

--- a/client/src/routes/collection/artists.tsx
+++ b/client/src/routes/collection/artists.tsx
@@ -37,9 +37,7 @@ export const RouteComponent = () => {
   const { data, fetchMore } = useSuspenseQuery<
     CollectionArtistsRouteQuery,
     CollectionArtistsRouteQueryVariables
-  >(COLLECTION_ARTISTS_ROUTE_QUERY, {
-    suspensePolicy: 'initial',
-  });
+  >(COLLECTION_ARTISTS_ROUTE_QUERY);
 
   const pageInfo = data.me?.followedArtists?.pageInfo;
   const artists =

--- a/client/src/routes/collection/playlists.tsx
+++ b/client/src/routes/collection/playlists.tsx
@@ -93,10 +93,7 @@ export const RouteComponent = () => {
   const { data, fetchMore } = useSuspenseQuery<
     CollectionPlaylistsRouteQuery,
     CollectionTracksRouteQueryVariables
-  >(COLLECTION_PLAYLISTS_ROUTE_QUERY, {
-    suspensePolicy: 'initial',
-    variables: { limit: 50 },
-  });
+  >(COLLECTION_PLAYLISTS_ROUTE_QUERY, { variables: { limit: 50 } });
 
   if (!data.me || !data.me.playlists || !data.me.tracks || !data.me.episodes) {
     throw new Error('Something went wrong');

--- a/client/src/routes/collection/tracks.tsx
+++ b/client/src/routes/collection/tracks.tsx
@@ -83,10 +83,7 @@ export const RouteComponent = () => {
   const { client, data, fetchMore } = useSuspenseQuery<
     CollectionTracksRouteQuery,
     CollectionTracksRouteQueryVariables
-  >(COLLECTION_TRACKS_ROUTE_QUERY, {
-    suspensePolicy: 'initial',
-    variables: { limit: 50 },
-  });
+  >(COLLECTION_TRACKS_ROUTE_QUERY, { variables: { limit: 50 } });
 
   useEffect(() => {
     const { cache } = client;

--- a/client/src/routes/playlists/playlist.tsx
+++ b/client/src/routes/playlists/playlist.tsx
@@ -65,10 +65,7 @@ export const RouteComponent = () => {
   const { data, fetchMore } = useSuspenseQuery<
     PlaylistQuery,
     PlaylistQueryVariables
-  >(PLAYLIST_QUERY, {
-    suspensePolicy: 'initial',
-    variables: { id: playlistId },
-  });
+  >(PLAYLIST_QUERY, { variables: { id: playlistId } });
   const playlist = data.playlist;
 
   if (!playlist) {

--- a/client/src/routes/queue.tsx
+++ b/client/src/routes/queue.tsx
@@ -15,7 +15,7 @@ import TrackNumberCell from '../components/TrackNumberCell';
 import TrackPositionCell from '../components/TrackPositionCell';
 import TrackTitleCell from '../components/TrackTitleCell';
 import usePlaybackState from '../hooks/usePlaybackState';
-import { useEffect, useRef } from 'react';
+import { startTransition, useEffect, useRef } from 'react';
 import usePrevious from '../hooks/usePrevious';
 import Duration from '../components/Duration';
 import { ListMusic } from 'lucide-react';
@@ -104,7 +104,6 @@ export const RouteComponent = () => {
     // The queue is volitile and can change often so its easiest to reload the
     // data each time this route is loaded.
     fetchPolicy: 'network-only',
-    suspensePolicy: 'initial',
   });
 
   const [resumePlayback] = useResumePlaybackMutation({
@@ -137,7 +136,9 @@ export const RouteComponent = () => {
       previousItem &&
       !isChangingTrack.current
     ) {
-      refetch();
+      startTransition(() => {
+        refetch();
+      });
     }
   }, [playbackState?.item, previousItem, refetch]);
 

--- a/client/src/routes/root.tsx
+++ b/client/src/routes/root.tsx
@@ -84,7 +84,7 @@ const Playlists = () => {
     useState<HTMLUListElement | null>(null);
   const { data, fetchMore } = useSuspenseQuery<RootQuery, RootQueryVariables>(
     ROOT_QUERY,
-    { suspensePolicy: 'initial', variables: { limit: 50 } }
+    { variables: { limit: 50 } }
   );
 
   const playbackState = usePlaybackState<PlaybackState>({

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "react-apollo-spotify-demo",
       "dependencies": {
-        "@apollo/client": "^3.8.0-alpha.8",
+        "@apollo/client": "^3.8.0-alpha.15",
         "@apollo/datasource-rest": "^5.0.2",
         "@apollo/server": "^4.4.1",
         "@apollo/subgraph": "^2.3.3",
@@ -123,17 +123,17 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.8.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.8.tgz",
-      "integrity": "sha512-rxV6Jn61UjAQsQ9Qr2ftSW0dXrVcYPs1BumAjGNC3FOe0HV3Mo98BZOyFg1+XZZVtiS8cU5C6R9W4c2t8+tcoA==",
+      "version": "3.8.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.15.tgz",
+      "integrity": "sha512-725uCJ7m/+39nHj7tUb3NMr3I6Fyth3GFtMjSVx5w4FngZiLF4xszXzH8sGZxfAlKagXMVKK0EDncAoFXoY16A==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.17.4",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -4215,9 +4215,9 @@
       }
     },
     "node_modules/@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4226,9 +4226,9 @@
       }
     },
     "node_modules/@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -4237,9 +4237,9 @@
       }
     },
     "node_modules/@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -9863,12 +9863,24 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
-      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.4.tgz",
+      "integrity": "sha512-KoRKlIfGkU9j9FPlaIMvKJ8caF1Xdi2zeonabg1UPYutHp8jqoJCezR2XzP1yzBggs8LwTDBtQbwIY1BHpp1iw==",
       "dependencies": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/optimism/node_modules/@wry/trie": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/optionator": {
@@ -12912,17 +12924,17 @@
       "requires": {}
     },
     "@apollo/client": {
-      "version": "3.8.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.8.tgz",
-      "integrity": "sha512-rxV6Jn61UjAQsQ9Qr2ftSW0dXrVcYPs1BumAjGNC3FOe0HV3Mo98BZOyFg1+XZZVtiS8cU5C6R9W4c2t8+tcoA==",
+      "version": "3.8.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.15.tgz",
+      "integrity": "sha512-725uCJ7m/+39nHj7tUb3NMr3I6Fyth3GFtMjSVx5w4FngZiLF4xszXzH8sGZxfAlKagXMVKK0EDncAoFXoY16A==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
-        "@wry/context": "^0.7.0",
-        "@wry/equality": "^0.5.0",
-        "@wry/trie": "^0.3.0",
+        "@wry/context": "^0.7.3",
+        "@wry/equality": "^0.5.6",
+        "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.16.1",
+        "optimism": "^0.17.4",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -15895,25 +15907,25 @@
       }
     },
     "@wry/context": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.0.tgz",
-      "integrity": "sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.3.tgz",
+      "integrity": "sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/equality": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.3.tgz",
-      "integrity": "sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.6.tgz",
+      "integrity": "sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==",
       "requires": {
         "tslib": "^2.3.0"
       }
     },
     "@wry/trie": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
-      "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
+      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -19953,12 +19965,23 @@
       }
     },
     "optimism": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.16.2.tgz",
-      "integrity": "sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==",
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.17.4.tgz",
+      "integrity": "sha512-KoRKlIfGkU9j9FPlaIMvKJ8caF1Xdi2zeonabg1UPYutHp8jqoJCezR2XzP1yzBggs8LwTDBtQbwIY1BHpp1iw==",
       "requires": {
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.3.0"
+        "@wry/trie": "^0.3.0",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@wry/trie": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.3.2.tgz",
+          "integrity": "sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "optionator": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "trailingComma": "es5"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.0-alpha.8",
+    "@apollo/client": "^3.8.0-alpha.15",
     "@apollo/datasource-rest": "^5.0.2",
     "@apollo/server": "^4.4.1",
     "@apollo/subgraph": "^2.3.3",


### PR DESCRIPTION
The latest `@apollo/client` alphas deprecated the `suspensePolicy` option in favor of using React's `startTransition` and `useDeferredValue` APIs. This PR updates all the queries that used the old `suspensePolicy` in favor of the new pattern.