### PR TITLE
chore: remove number from codegen ID input type union

### DIFF
--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -7,7 +7,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }

--- a/codegen.ts
+++ b/codegen.ts
@@ -24,6 +24,7 @@ const config: CodegenConfig = {
           CountryCode: 'string',
           DateTime: 'string',
           ErrorRate: 'number',
+          ID: 'string',
           Timestamp: 'number',
         },
         namingConvention: {

--- a/codegen.ts
+++ b/codegen.ts
@@ -233,6 +233,10 @@ const config: CodegenConfig = {
           },
         },
         scalars: {
+          ID: {
+            input: 'string',
+            output: 'string',
+          },
           CountryCode: 'string',
           DateTime: 'Date',
           ErrorRate: 'number',

--- a/codegen.ts
+++ b/codegen.ts
@@ -234,10 +234,7 @@ const config: CodegenConfig = {
           },
         },
         scalars: {
-          ID: {
-            input: 'string',
-            output: 'string',
-          },
+          ID: 'string',
           CountryCode: 'string',
           DateTime: 'Date',
           ErrorRate: 'number',

--- a/server/src/resolvers/types.ts
+++ b/server/src/resolvers/types.ts
@@ -14,7 +14,7 @@ export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string | number; output: string; }
+  ID: { input: string; output: string; }
   String: { input: string; output: string; }
   Boolean: { input: boolean; output: boolean; }
   Int: { input: number; output: number; }


### PR DESCRIPTION
Minor fix related to https://github.com/apollographql/spotify-showcase/pull/57 which overrides the built-in scalar ID input value to `string` from `string | number`, since Spotify IDs are always strings.