### PR TITLE
chore: use Apollo Client beta and `useBackgroundQuery`/`useReadQuery`

### DIFF
--- a/client/src/components/CurrentUserMenu.tsx
+++ b/client/src/components/CurrentUserMenu.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { CurrentUserQuery, CurrentUserQueryVariables } from '../types/api';
 import DropdownMenu from './DropdownMenu';
 import Avatar from './Avatar';

--- a/client/src/components/Layout/Sidebar.tsx
+++ b/client/src/components/Layout/Sidebar.tsx
@@ -1,9 +1,5 @@
 import { forwardRef, ReactNode } from 'react';
-import {
-  gql,
-  OperationVariables,
-  useFragment_experimental as useFragment,
-} from '@apollo/client';
+import { gql, OperationVariables, useFragment } from '@apollo/client';
 import { Link } from 'react-router-dom';
 import { Library, Home, Search, Heart, Volume2, Bookmark } from 'lucide-react';
 import {

--- a/client/src/components/LikeControl.tsx
+++ b/client/src/components/LikeControl.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   LikeControlQuery,
   LikeControlQueryVariables,

--- a/client/src/components/PlaybackStateSubscriber.tsx
+++ b/client/src/components/PlaybackStateSubscriber.tsx
@@ -1,9 +1,5 @@
 import { useEffect } from 'react';
-import {
-  ApolloError,
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { ApolloError, gql, useSuspenseQuery } from '@apollo/client';
 import {
   PlaybackStateSubscriberQuery,
   PlaybackStateSubscriberSubscription,

--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -1,8 +1,5 @@
 import cx from 'classnames';
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   Action,
   RepeatMode,

--- a/client/src/components/PlaylistTable.tsx
+++ b/client/src/components/PlaylistTable.tsx
@@ -1,8 +1,4 @@
-import {
-  gql,
-  useFragment_experimental as useFragment,
-  OperationVariables,
-} from '@apollo/client';
+import { gql, useFragment, OperationVariables } from '@apollo/client';
 import { createColumnHelper } from '@tanstack/react-table';
 import { Clock, Podcast } from 'lucide-react';
 import {

--- a/client/src/hooks/usePlaybackState.ts
+++ b/client/src/hooks/usePlaybackState.ts
@@ -1,5 +1,5 @@
 import {
-  useFragment_experimental as useFragment,
+  useFragment,
   DocumentNode,
   TypedDocumentNode,
   OperationVariables,

--- a/client/src/hooks/useSavedTracksContains.ts
+++ b/client/src/hooks/useSavedTracksContains.ts
@@ -2,8 +2,8 @@ import {
   gql,
   TypedDocumentNode,
   useApolloClient,
-  useFragment_experimental as useFragment,
-  useSuspenseQuery_experimental as useSuspenseQuery,
+  useFragment,
+  useSuspenseQuery,
 } from '@apollo/client';
 import { useEffect } from 'react';
 import {

--- a/client/src/routes/albums/album.tsx
+++ b/client/src/routes/albums/album.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 import {
   AlbumRouteQuery,

--- a/client/src/routes/artists/artist.tsx
+++ b/client/src/routes/artists/artist.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import cx from 'classnames';
 import { useParams } from 'react-router-dom';
 import { Get } from 'type-fest';

--- a/client/src/routes/collection/albums.tsx
+++ b/client/src/routes/collection/albums.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import AlbumTile from '../../components/AlbumTile';
 import Skeleton from '../../components/Skeleton';
 import TileGrid from '../../components/TileGrid';

--- a/client/src/routes/collection/artists.tsx
+++ b/client/src/routes/collection/artists.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   CollectionArtistsRouteQuery,
   CollectionArtistsRouteQueryVariables,

--- a/client/src/routes/collection/playlists.tsx
+++ b/client/src/routes/collection/playlists.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   CollectionPlaylistsRouteQuery,
   CollectionTracksRouteQueryVariables,

--- a/client/src/routes/collection/podcasts.tsx
+++ b/client/src/routes/collection/podcasts.tsx
@@ -1,8 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-  TypedDocumentNode,
-} from '@apollo/client';
+import { gql, useSuspenseQuery, TypedDocumentNode } from '@apollo/client';
 import CoverPhoto from '../../components/CoverPhoto';
 import MediaTile from '../../components/MediaTile';
 import OffsetBasedPaginationObserver from '../../components/OffsetBasedPaginationObserver';

--- a/client/src/routes/collection/tracks.tsx
+++ b/client/src/routes/collection/tracks.tsx
@@ -1,8 +1,5 @@
 import { useEffect } from 'react';
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { Get } from 'type-fest';
 import { Heart } from 'lucide-react';
 import { createColumnHelper } from '@tanstack/react-table';

--- a/client/src/routes/episodes/episode.tsx
+++ b/client/src/routes/episodes/episode.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { useParams } from 'react-router-dom';
 import { EpisodeRouteQuery, EpisodeRouteQueryVariables } from '../../types/api';
 import Button from '../../components/Button';

--- a/client/src/routes/playlists/playlist.tsx
+++ b/client/src/routes/playlists/playlist.tsx
@@ -1,8 +1,5 @@
 import { useParams } from 'react-router-dom';
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   PlaylistQuery,
   PlaylistQueryVariables,

--- a/client/src/routes/queue.tsx
+++ b/client/src/routes/queue.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   QueueRouteQuery,
   QueueRouteQueryVariables,

--- a/client/src/routes/root.suspense.mdx
+++ b/client/src/routes/root.suspense.mdx
@@ -7,10 +7,7 @@ tab: Loading with Suspense
 This page loads data with Apollo's `useSuspenseQuery` hook.
 
 ```tsx
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 
 const ROOT_QUERY = gql`
   query RootQuery($offset: Int, $limit: Int) {

--- a/client/src/routes/root.tsx
+++ b/client/src/routes/root.tsx
@@ -1,9 +1,5 @@
 import { Fragment, ReactNode, useRef, useState } from 'react';
-import cx from 'classnames';
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { Outlet, useParams } from 'react-router-dom';
 import {
   RootQuery,

--- a/client/src/routes/settings.tsx
+++ b/client/src/routes/settings.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import {
   SettingsQuery,
   SettingsQueryVariables,

--- a/client/src/routes/shows/show.tsx
+++ b/client/src/routes/shows/show.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import cx from 'classnames';
 import { useParams } from 'react-router-dom';
 import {

--- a/client/src/routes/tracks/track.tsx
+++ b/client/src/routes/tracks/track.tsx
@@ -1,7 +1,4 @@
-import {
-  gql,
-  useSuspenseQuery_experimental as useSuspenseQuery,
-} from '@apollo/client';
+import { gql, useSuspenseQuery } from '@apollo/client';
 import { TrackRouteQuery, TrackRouteQueryVariables } from '../../types/api';
 import { useParams } from 'react-router-dom';
 import AlbumTracksTable from '../../components/AlbumTracksTable';

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "react-apollo-spotify-demo",
       "dependencies": {
-        "@apollo/client": "^3.8.0-alpha.15",
+        "@apollo/client": "^3.8.0-beta.0",
         "@apollo/datasource-rest": "^5.0.2",
         "@apollo/server": "^4.4.1",
         "@apollo/subgraph": "^2.3.3",
@@ -123,9 +123,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.8.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.15.tgz",
-      "integrity": "sha512-725uCJ7m/+39nHj7tUb3NMr3I6Fyth3GFtMjSVx5w4FngZiLF4xszXzH8sGZxfAlKagXMVKK0EDncAoFXoY16A==",
+      "version": "3.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-beta.0.tgz",
+      "integrity": "sha512-/eepswGsajGSbyc7W36YlnYEfsL+O6eipvFh6FbhaQom1CRdVTxxcEB2i7lW8SJ96AMNZge+PLnCg5KTXTeveA==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.3",
@@ -13452,9 +13452,9 @@
       "requires": {}
     },
     "@apollo/client": {
-      "version": "3.8.0-alpha.15",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-alpha.15.tgz",
-      "integrity": "sha512-725uCJ7m/+39nHj7tUb3NMr3I6Fyth3GFtMjSVx5w4FngZiLF4xszXzH8sGZxfAlKagXMVKK0EDncAoFXoY16A==",
+      "version": "3.8.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-beta.0.tgz",
+      "integrity": "sha512-/eepswGsajGSbyc7W36YlnYEfsL+O6eipvFh6FbhaQom1CRdVTxxcEB2i7lW8SJ96AMNZge+PLnCg5KTXTeveA==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "trailingComma": "es5"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.0-alpha.15",
+    "@apollo/client": "^3.8.0-beta.0",
     "@apollo/datasource-rest": "^5.0.2",
     "@apollo/server": "^4.4.1",
     "@apollo/subgraph": "^2.3.3",


### PR DESCRIPTION
This PR uses the latest Apollo Client beta and updates import statements to drop the `_experimental` suffix from hooks. It also makes use of `useBackgroundQuery`/`useReadQuery` in `client/src/routes/index.tsx`.