### PR TITLE
Fix pagination for loading tracks

### DIFF
--- a/client/src/components/Layout/Main.tsx
+++ b/client/src/components/Layout/Main.tsx
@@ -1,17 +1,22 @@
-import { forwardRef, ReactNode } from 'react';
+import { forwardRef, ReactNode, useRef } from 'react';
+import ScrollContainerContext from '../ScrollContainerContext';
 
 interface MainProps {
   children: ReactNode;
 }
 
 const Main = forwardRef<HTMLElement, MainProps>(({ children }, ref) => {
+  const scrollRef = useRef<HTMLElement>(null);
+
   return (
     <main
       className="[--main-header--height:80px] [--main-content--padding:2rem] [grid-area:main-view] flex flex-col text-primary h-full overflow-y-auto relative rounded-md overflow-hidden"
       ref={ref}
     >
-      <article className="flex flex-col flex-1 overflow-y-auto">
-        {children}
+      <article ref={scrollRef} className="flex flex-col flex-1 overflow-y-auto">
+        <ScrollContainerContext.Provider value={scrollRef}>
+          {children}
+        </ScrollContainerContext.Provider>
       </article>
     </main>
   );


### PR DESCRIPTION
When looking at a playlist or page that used pagination to load more tracks, the `IntersectionObserver` was not firing because it did not properly attach a scroll container. This PR restores the pagination functionality when scrolling to load more tracks.