### PR TITLE
Update address for supergraph for dev router config

### DIFF
--- a/.apollo/router-config.yaml
+++ b/.apollo/router-config.yaml
@@ -16,7 +16,7 @@ sandbox:
   enabled: true
 supergraph:
   introspection: true
-  listen: 127.0.0.1:4000
+  listen: 0.0.0.0:4000
 homepage:
   enabled: false
 apq:


### PR DESCRIPTION
I was having troubles running the router in dev using `127.0.0.` so this PR updates to use `0.0.0.0` instead.
