### PR TITLE
Upgrade to latest `rc` version of apollo and remove deprecated `suspenseCache` option

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "client",
       "version": "0.1.0",
       "dependencies": {
-        "@apollo/client": "^3.8.0-beta.7",
+        "@apollo/client": "^3.8.0-rc.1",
         "@radix-ui/react-context-menu": "^2.1.3",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.4",
@@ -103,9 +103,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.8.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-beta.7.tgz",
-      "integrity": "sha512-LoIn1ocMF+YBzpUBn056b+ZdmF7trK35BJCTny+oZ9bm1xqv7f/SivyAr++qz4QSXNJqgnNdr0Zjh6LeIsTIcA==",
+      "version": "3.8.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-rc.1.tgz",
+      "integrity": "sha512-YqJeoLRqRSX5Rzad6D4NYwRNIlY3cmSVao6kF8WJZ0rb2POf1etFcQ5ocuKlcXtUw+WZlNEGeootV2wqdXwJaw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.3",
@@ -113,7 +113,7 @@
         "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.4",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",
@@ -9658,9 +9658,9 @@
       }
     },
     "@apollo/client": {
-      "version": "3.8.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-beta.7.tgz",
-      "integrity": "sha512-LoIn1ocMF+YBzpUBn056b+ZdmF7trK35BJCTny+oZ9bm1xqv7f/SivyAr++qz4QSXNJqgnNdr0Zjh6LeIsTIcA==",
+      "version": "3.8.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.8.0-rc.1.tgz",
+      "integrity": "sha512-YqJeoLRqRSX5Rzad6D4NYwRNIlY3cmSVao6kF8WJZ0rb2POf1etFcQ5ocuKlcXtUw+WZlNEGeootV2wqdXwJaw==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.7.3",
@@ -9668,7 +9668,7 @@
         "@wry/trie": "^0.4.3",
         "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
-        "optimism": "^0.17.4",
+        "optimism": "^0.17.5",
         "prop-types": "^15.7.2",
         "response-iterator": "^0.2.6",
         "symbol-observable": "^4.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@apollo/client": "^3.8.0-rc.1",
+        "@apollo/persisted-query-lists": "^1.0.0",
         "@radix-ui/react-context-menu": "^2.1.3",
         "@radix-ui/react-dialog": "^1.0.3",
         "@radix-ui/react-dropdown-menu": "^2.0.4",
@@ -141,6 +142,18 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@apollo/persisted-query-lists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/persisted-query-lists/-/persisted-query-lists-1.0.0.tgz",
+      "integrity": "sha512-PrqOKBrI01tqGwjji97Ux4L3z8bIkUJ9QJ7kGt13CzH6d1cUx+4IehF7p2Tceo1Rwkr5cAR98RYfzMCd0JALTQ==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@apollo/client": "^3.2.0 || ^3.8.0-alpha",
+        "graphql": "14.x || 15.x || 16.x"
       }
     },
     "node_modules/@apollo/rover": {
@@ -9676,6 +9689,12 @@
         "tslib": "^2.3.0",
         "zen-observable-ts": "^1.2.5"
       }
+    },
+    "@apollo/persisted-query-lists": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/persisted-query-lists/-/persisted-query-lists-1.0.0.tgz",
+      "integrity": "sha512-PrqOKBrI01tqGwjji97Ux4L3z8bIkUJ9QJ7kGt13CzH6d1cUx+4IehF7p2Tceo1Rwkr5cAR98RYfzMCd0JALTQ==",
+      "requires": {}
     },
     "@apollo/rover": {
       "version": "0.16.2",

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,7 @@
     "node": "18"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.0-beta.7",
+    "@apollo/client": "^3.8.0-rc.1",
     "@radix-ui/react-context-menu": "^2.1.3",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.0-rc.1",
+    "@apollo/persisted-query-lists": "^1.0.0",
     "@radix-ui/react-context-menu": "^2.1.3",
     "@radix-ui/react-dialog": "^1.0.3",
     "@radix-ui/react-dropdown-menu": "^2.0.4",

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,5 +1,5 @@
 import ReactDOM from 'react-dom/client';
-import { ApolloProvider, SuspenseCache } from '@apollo/client';
+import { ApolloProvider } from '@apollo/client';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import reportWebVitals from './reportWebVitals';
 import { RouterProvider } from 'react-router-dom';
@@ -21,7 +21,7 @@ const root = ReactDOM.createRoot(
 root.render(
   // TODO: Re-enable strict mode once https://github.com/apollographql/apollo-client/issues/10428 is fixed
   // <React.StrictMode>
-  <ApolloProvider client={client} suspenseCache={new SuspenseCache()}>
+  <ApolloProvider client={client}>
     <Tooltip.Provider delayDuration={300}>
       <BackgroundColorProvider>
         <RouterProvider router={router} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "ISC",
       "dependencies": {
         "@apollo/generate-persisted-query-manifest": "^1.0.0",
-        "@apollo/persisted-query-lists": "^1.0.0",
         "@graphql-codegen/cli": "^4.0.1",
         "@graphql-codegen/fragment-matcher": "^5.0.0",
         "@graphql-codegen/typescript": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@apollo/generate-persisted-query-manifest": "^1.0.0",
-    "@apollo/persisted-query-lists": "^1.0.0",
     "@graphql-codegen/cli": "^4.0.1",
     "@graphql-codegen/fragment-matcher": "^5.0.0",
     "@graphql-codegen/typescript": "^4.0.1",


### PR DESCRIPTION
The `suspenseCache` is now created lazily in the client behind-the-scenes rather than requiring instantiation (https://github.com/apollographql/apollo-client/pull/11053). This PR removes the instantiation of `SuspenseCache`.