### PR TITLE
Let rover decide router version to get working subscriptions

### DIFF
--- a/.apollo/router-config.yaml
+++ b/.apollo/router-config.yaml
@@ -21,8 +21,13 @@ homepage:
   enabled: false
 apq:
   enabled: false
-preview_persisted_queries:
-  enabled: true
+#####################
+# Enable to use persisted queries. You must set the env var
+# `APOLLO_ROVER_DEV_ROUTER_VERSION=1.25.0-alpha.0` for this to work.
+#####################
+# preview_persisted_queries:
+#   enabled: true
+
 #####################
 # Uncomment the following to enable local subscriptions. You must have an
 # enterprise account or enterprise trial to use this.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start:client": "npm run start --prefix=client",
     "start:spotify": "npm run start --prefix=subgraphs/spotify",
     "start:playback": "npm run start --prefix=subgraphs/playback",
-    "start:router": "APOLLO_ROVER_DEV_ROUTER_VERSION=1.25.0-alpha.0 rover dev --supergraph-config=spotify.yaml --router-config=.apollo/router-config.yaml"
+    "start:router": "rover dev --supergraph-config=spotify.yaml --router-config=.apollo/router-config.yaml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
There is currently a bug in the `v1.25.0-alpha.0` version of the router that prevents subscriptions from working. This version was necessary to get persisted queries to work (#75). For now, disable persisted queries and use the stable router version to get working subscriptions.
