### PR TITLE
Ensure token refresh only tries once at a time + handle errors in subscription endpoint

### DIFF
--- a/client/src/utils/oauth.ts
+++ b/client/src/utils/oauth.ts
@@ -102,5 +102,9 @@ export const refreshAccessToken =
       return res.json();
     });
 
+    refreshAccessTokenPromise.finally(() => {
+      refreshAccessTokenPromise = null;
+    });
+
     return refreshAccessTokenPromise;
   };

--- a/client/src/utils/oauth.ts
+++ b/client/src/utils/oauth.ts
@@ -69,15 +69,22 @@ export const exchangeToken = async (
   return res.json();
 };
 
+let refreshAccessTokenPromise: Promise<RefreshAccessTokenResponse> | null =
+  null;
+
 export const refreshAccessToken =
   async (): Promise<RefreshAccessTokenResponse> => {
+    if (refreshAccessTokenPromise) {
+      return refreshAccessTokenPromise;
+    }
+
     const refreshToken = readToken('refresh');
 
     if (!refreshToken) {
       throw new Error('No refresh token present');
     }
 
-    const res = await fetch(SPOTIFY_TOKEN_URL, {
+    refreshAccessTokenPromise = fetch(SPOTIFY_TOKEN_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -87,11 +94,13 @@ export const refreshAccessToken =
         grant_type: 'refresh_token',
         refresh_token: refreshToken,
       }),
+    }).then((res) => {
+      if (!res.ok) {
+        throw new Error('Not authorized');
+      }
+
+      return res.json();
     });
 
-    if (!res.ok) {
-      throw new Error('Not authorized');
-    }
-
-    return res.json();
+    return refreshAccessTokenPromise;
   };

--- a/subgraphs/playback/src/resolvers/Subscription.ts
+++ b/subgraphs/playback/src/resolvers/Subscription.ts
@@ -1,6 +1,6 @@
 import { SubscriptionResolvers } from '../__generated__/resolvers-types';
 import { Spotify } from '../dataSources/spotify.types';
-import { map, distinctUntilChanged } from 'rxjs';
+import { catchError, map, distinctUntilChanged, of } from 'rxjs';
 import { equal } from '@wry/equality';
 import { GraphQLResolveInfo } from 'graphql';
 import { omit } from 'lodash';
@@ -35,14 +35,15 @@ export const Subscription: SubscriptionResolvers = {
           ) as Spotify.Object.PlaybackState;
         }),
         distinctUntilChanged((prev, curr) => equal(prev, curr)),
-        map(
-          (result) =>
-            result && {
-              data: {
-                playbackStateChanged: { ...result, timestamp: Date.now() },
-              },
-            }
-        )
+        map((result) => ({
+          data: {
+            playbackStateChanged: result && {
+              ...result,
+              timestamp: Date.now(),
+            },
+          },
+        })),
+        catchError((error) => of({ error }))
       );
 
       return eachValueFrom(source$);


### PR DESCRIPTION
Update the subscription endpoint to add errors as the `resolve` function expects. Also ensure that we only request a single token refresh at a time to prevent issues when multiple queries are trying to send requests simultaneously.