### PR TITLE
Fix type of artists field in AlbumSimplified

### DIFF
--- a/shared/spotify-api/src/types.ts
+++ b/shared/spotify-api/src/types.ts
@@ -56,7 +56,7 @@ export namespace Spotify {
     export interface AlbumSimplified {
       album_type: AlbumType;
       album_group: AlbumGroup;
-      artists: ArtistSimplified;
+      artists: ArtistSimplified[];
       available_markets: CountryCode[];
       external_urls: ExternalUrl;
       href: string;


### PR DESCRIPTION
The `artists` type in `Spotify.Object.AlbumSimplified` should be an array, not an object.