### PR TITLE
Remove albumGroup field that is not present in the REST API

### DIFF
--- a/subgraphs/spotify/schema.graphql
+++ b/subgraphs/spotify/schema.graphql
@@ -603,11 +603,6 @@ type ArtistAlbumsConnection {
 }
 
 type ArtistAlbumEdge {
-  """
-  The album group this album belongs to.
-  """
-  albumGroup: AlbumGroup!
-
   "Spotify catalog information for the album."
   node: Album!
 }

--- a/subgraphs/spotify/src/__generated__/resolvers-types.ts
+++ b/subgraphs/spotify/src/__generated__/resolvers-types.ts
@@ -216,8 +216,6 @@ export type ArtistAlbumsArgs = {
 
 export type ArtistAlbumEdge = {
   __typename?: 'ArtistAlbumEdge';
-  /** The album group this album belongs to. */
-  albumGroup: AlbumGroup;
   /** Spotify catalog information for the album. */
   node: Album;
 };
@@ -2362,7 +2360,6 @@ export type ArtistResolvers<ContextType = ContextValue, ParentType extends Resol
 }>;
 
 export type ArtistAlbumEdgeResolvers<ContextType = ContextValue, ParentType extends ResolversParentTypes['ArtistAlbumEdge'] = ResolversParentTypes['ArtistAlbumEdge']> = ResolversObject<{
-  albumGroup?: Resolver<ResolversTypes['AlbumGroup'], ParentType, ContextType>;
   node?: Resolver<ResolversTypes['Album'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/subgraphs/spotify/src/resolvers/ArtistAlbumEdge.ts
+++ b/subgraphs/spotify/src/resolvers/ArtistAlbumEdge.ts
@@ -1,9 +1,6 @@
 import { ArtistAlbumEdgeResolvers } from '../__generated__/resolvers-types';
-import { itself, prop } from './helpers';
+import { itself } from './helpers';
 
 export const ArtistAlbumEdge: ArtistAlbumEdgeResolvers = {
-  // TODO: Remove this field since it is not available in the API. Temporarily
-  // point to album type
-  albumGroup: prop('album_type'),
   node: itself(),
 };


### PR DESCRIPTION
Now that Spotify's developer documentation has been much improved, I discovered the `albumGroup` field is actually not a field returned for artist albums. This removes that field from the schema.