### PR TITLE
Better sidebar and playbar loading states

### DIFF
--- a/client/src/components/LikeButton.tsx
+++ b/client/src/components/LikeButton.tsx
@@ -4,19 +4,27 @@ import Tooltip from './Tooltip';
 
 export interface LikeButtonProps {
   className?: string;
+  disabled?: boolean;
   liked: boolean;
   onClick?: () => void;
   size?: LucideProps['size'];
 }
 
-const LikeButton = ({ className, liked, onClick, size }: LikeButtonProps) => {
+const LikeButton = ({
+  disabled,
+  className,
+  liked,
+  onClick,
+  size,
+}: LikeButtonProps) => {
   return (
     <Tooltip
       content={liked ? 'Remove from Your Library' : 'Save to Your Library'}
     >
       <button
+        disabled={disabled}
         className={cx(
-          'text-muted bg-none outline-0 border-none cursor-pointer transition-colors ease-out hover:text-primary',
+          'text-muted bg-none outline-0 border-none cursor-pointer transition-colors ease-out hover:text-primary disabled:text-muted disabled:opacity-30 disabled:pointer-events-none',
           className,
           { 'text-theme hover:text-theme-light': liked }
         )}

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -5,7 +5,7 @@ import ScrollContainerContext from './ScrollContainerContext';
 import Playbar from './Playbar';
 import PlaybackStateSubscriber from './PlaybackStateSubscriber';
 import { TypedDocumentNode, gql, useSuspenseQuery } from '@apollo/client';
-import { SidebarQuery, SidebarQueryVariables } from '../types/api';
+import { RepeatMode, SidebarQuery, SidebarQueryVariables } from '../types/api';
 import PlaylistSidebarLink from './PlaylistSidebarLink';
 import { Library } from 'lucide-react';
 import CoverPhoto from './CoverPhoto';
@@ -16,6 +16,18 @@ import YourEpisodesPlaylistCoverPhoto from './YourEpisodesPlaylistCoverPhoto';
 import { randomBetween, range } from '../utils/common';
 import Skeleton from './Skeleton';
 import CurrentUserMenu from './CurrentUserMenu';
+import LikeButton from './LikeButton';
+import PlayButton from './PlayButton';
+import ShufflePlaybackControl from './ShufflePlaybackControl';
+import SkipToPreviousControl from './SkipToPreviousControl';
+import SkipToNextControl from './SkipToNextControl';
+import PlaybackItemProgressBar from './PlaybackItemProgressBar';
+import RepeatControl from './RepeatControl';
+import QueueControlButton from './QueueControlButton';
+import PlaybarControlButton from './PlaybarControlButton';
+import DeviceIcon from './DeviceIcon';
+import MuteControl from './MuteControl';
+import VolumeBar from './VolumeBar';
 
 const LoggedInLayout = () => {
   return (
@@ -182,13 +194,13 @@ const LoadingState = () => {
   return (
     <Layout type="player">
       <Layout.Sidebar>
-        <Layout.Sidebar.Section className="flex flex-col flex-1">
+        <Layout.Sidebar.Section className="flex-1 overflow-hidden flex flex-col pb-0">
           <header className="px-4 py-2">
             <h2 className="text-muted flex gap-2 items-center py-2 text-base">
               <Library /> Your Library
             </h2>
           </header>
-          <div className="flex-1">
+          <div className="overflow-y-auto flex-1 -mx-1 px-3">
             {skeletons.map((num) => (
               <li key={num} className="px-0 py-2">
                 <Skeleton.Text key={num} width={`${randomBetween(40, 60)}%`} />
@@ -205,6 +217,44 @@ const LoadingState = () => {
           </div>
         </header>
       </Layout.Main>
+      <footer className="[grid-area:playbar] flex flex-col">
+        <div className="items-center grid grid-cols-[30%_1fr_30%] text-primary py-5 px-6">
+          <div className="flex items-center gap-4">
+            <Skeleton.CoverPhoto size="4rem" />
+            <div className="flex flex-col gap-2">
+              <Skeleton.Text width="4rem" />
+              <Skeleton.Text width="8rem" />
+            </div>
+            <LikeButton disabled liked={false} />
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-5 justify-center">
+              <ShufflePlaybackControl
+                disallowed
+                size="1.25rem"
+                shuffled={false}
+              />
+              <SkipToPreviousControl disallowed progressMs={0} />
+              <PlayButton disabled playing={false} size="2.5rem" />
+              <SkipToNextControl disallowed />
+              <RepeatControl disallowed repeatState={RepeatMode.Off} />
+            </div>
+            <PlaybackItemProgressBar playbackState={null} />
+          </div>
+          <div className="flex justify-end gap-4 items-center">
+            <QueueControlButton />
+            <PlaybarControlButton
+              disallowed
+              icon={<DeviceIcon device={undefined} strokeWidth={1.5} />}
+              tooltip="Connect to a device"
+            />
+            <div className="flex gap-2 items-center">
+              <MuteControl disallowed volumePercent={100} />
+              <VolumeBar volumePercent={100} width="100px" />
+            </div>
+          </div>
+        </div>
+      </footer>
     </Layout>
   );
 };

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -2,7 +2,7 @@ import { ReactNode, Suspense, useRef } from 'react';
 import { Outlet } from 'react-router-dom';
 import Layout from './Layout';
 import ScrollContainerContext from './ScrollContainerContext';
-import Playbar from './Playbar';
+import Playbar, { LoadingState as PlaybarLoadingState } from './Playbar';
 import PlaybackStateSubscriber from './PlaybackStateSubscriber';
 import { TypedDocumentNode, gql, useSuspenseQuery } from '@apollo/client';
 import { RepeatMode, SidebarQuery, SidebarQueryVariables } from '../types/api';
@@ -217,44 +217,7 @@ const LoadingState = () => {
           </div>
         </header>
       </Layout.Main>
-      <footer className="[grid-area:playbar] flex flex-col">
-        <div className="items-center grid grid-cols-[30%_1fr_30%] text-primary py-5 px-6">
-          <div className="flex items-center gap-4">
-            <Skeleton.CoverPhoto size="4rem" />
-            <div className="flex flex-col gap-2">
-              <Skeleton.Text width="4rem" />
-              <Skeleton.Text width="8rem" />
-            </div>
-            <LikeButton disabled liked={false} />
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-5 justify-center">
-              <ShufflePlaybackControl
-                disallowed
-                size="1.25rem"
-                shuffled={false}
-              />
-              <SkipToPreviousControl disallowed progressMs={0} />
-              <PlayButton disabled playing={false} size="2.5rem" />
-              <SkipToNextControl disallowed />
-              <RepeatControl disallowed repeatState={RepeatMode.Off} />
-            </div>
-            <PlaybackItemProgressBar playbackState={null} />
-          </div>
-          <div className="flex justify-end gap-4 items-center">
-            <QueueControlButton />
-            <PlaybarControlButton
-              disallowed
-              icon={<DeviceIcon device={undefined} strokeWidth={1.5} />}
-              tooltip="Connect to a device"
-            />
-            <div className="flex gap-2 items-center">
-              <MuteControl disallowed volumePercent={100} />
-              <VolumeBar volumePercent={100} width="100px" />
-            </div>
-          </div>
-        </div>
-      </footer>
+      <PlaybarLoadingState />
     </Layout>
   );
 };

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -5,7 +5,7 @@ import ScrollContainerContext from './ScrollContainerContext';
 import Playbar, { LoadingState as PlaybarLoadingState } from './Playbar';
 import PlaybackStateSubscriber from './PlaybackStateSubscriber';
 import { TypedDocumentNode, gql, useSuspenseQuery } from '@apollo/client';
-import { RepeatMode, SidebarQuery, SidebarQueryVariables } from '../types/api';
+import { SidebarQuery, SidebarQueryVariables } from '../types/api';
 import PlaylistSidebarLink from './PlaylistSidebarLink';
 import { Library } from 'lucide-react';
 import CoverPhoto from './CoverPhoto';
@@ -16,18 +16,6 @@ import YourEpisodesPlaylistCoverPhoto from './YourEpisodesPlaylistCoverPhoto';
 import { randomBetween, range } from '../utils/common';
 import Skeleton from './Skeleton';
 import CurrentUserMenu from './CurrentUserMenu';
-import LikeButton from './LikeButton';
-import PlayButton from './PlayButton';
-import ShufflePlaybackControl from './ShufflePlaybackControl';
-import SkipToPreviousControl from './SkipToPreviousControl';
-import SkipToNextControl from './SkipToNextControl';
-import PlaybackItemProgressBar from './PlaybackItemProgressBar';
-import RepeatControl from './RepeatControl';
-import QueueControlButton from './QueueControlButton';
-import PlaybarControlButton from './PlaybarControlButton';
-import DeviceIcon from './DeviceIcon';
-import MuteControl from './MuteControl';
-import VolumeBar from './VolumeBar';
 
 const LoggedInLayout = () => {
   return (

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -189,7 +189,7 @@ const Container = ({ children }: ContainerProps) => {
 };
 
 const LoadingState = () => {
-  const skeletons = range(0, randomBetween(30, 40));
+  const skeletons = range(0, randomBetween(10, 15));
 
   return (
     <Layout type="player">
@@ -203,7 +203,19 @@ const LoadingState = () => {
           <div className="overflow-y-auto flex-1 -mx-1 px-3">
             {skeletons.map((num) => (
               <li key={num} className="px-0 py-2">
-                <Skeleton.Text key={num} width={`${randomBetween(40, 60)}%`} />
+                <div className="flex gap-2">
+                  <Skeleton.CoverPhoto size="3rem" />
+                  <div className="flex flex-col gap-4 flex-1">
+                    <Skeleton.Text
+                      width={`${randomBetween(40, 60)}%`}
+                      fontSize="1rem"
+                    />
+                    <Skeleton.Text
+                      width={`${randomBetween(50, 70)}%`}
+                      fontSize="0.75rem"
+                    />
+                  </div>
+                </div>
               </li>
             ))}
           </div>

--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -30,6 +30,8 @@ import useResumePlaybackMutation from '../mutations/useResumePlaybackMutation';
 import usePlaybackState from '../hooks/usePlaybackState';
 import QueueControlButton from './QueueControlButton';
 import { fragmentRegistry } from '../apollo/fragmentRegistry';
+import Skeleton from './Skeleton';
+import LikeButton from './LikeButton';
 
 const EPISODE_SKIP_FORWARD_AMOUNT = 15_000;
 
@@ -206,6 +208,49 @@ const Playbar = () => {
           <Volume1 size="1.125rem" /> Listening on {device.name}
         </Flex>
       )}
+    </footer>
+  );
+};
+
+export const LoadingState = () => {
+  return (
+    <footer className="[grid-area:playbar] flex flex-col">
+      <div className="items-center grid grid-cols-[30%_1fr_30%] text-primary py-5 px-6">
+        <div className="flex items-center gap-4">
+          <Skeleton.CoverPhoto size="4rem" />
+          <div className="flex flex-col gap-2">
+            <Skeleton.Text width="4rem" />
+            <Skeleton.Text width="8rem" />
+          </div>
+          <LikeButton disabled liked={false} />
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-5 justify-center">
+            <ShufflePlaybackControl
+              disallowed
+              size="1.25rem"
+              shuffled={false}
+            />
+            <SkipToPreviousControl disallowed progressMs={0} />
+            <PlayButton disabled playing={false} size="2.5rem" />
+            <SkipToNextControl disallowed />
+            <RepeatControl disallowed repeatState={RepeatMode.Off} />
+          </div>
+          <PlaybackItemProgressBar playbackState={null} />
+        </div>
+        <div className="flex justify-end gap-4 items-center">
+          <QueueControlButton />
+          <PlaybarControlButton
+            disallowed
+            icon={<DeviceIcon device={undefined} strokeWidth={1.5} />}
+            tooltip="Connect to a device"
+          />
+          <div className="flex gap-2 items-center">
+            <MuteControl disallowed volumePercent={100} />
+            <VolumeBar volumePercent={100} width="100px" />
+          </div>
+        </div>
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
The sidebar loading state still matched the old design and the playbar loading state was non-existent. This adds a better loading state for both.

<img width="2553" alt="Screenshot 2023-07-31 at 9 06 50 PM" src="https://github.com/apollographql/spotify-showcase/assets/565661/09d37bb0-f43a-43ea-9b84-f61f1ef99bbf">
