### PR TITLE
Deprecate the `user` field on the `CurrentUser` type and replace with a `profile` field

### DIFF
--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -36,6 +36,7 @@ export const OAUTH_SCOPES = [
   'user-read-currently-playing',
   'user-read-playback-position',
   'user-read-playback-state',
+  'user-read-private',
   'user-library-read',
   'user-library-modify',
   'user-top-read',

--- a/codegen.ts
+++ b/codegen.ts
@@ -176,10 +176,13 @@ const config: CodegenConfig = {
           ArtistAlbumEdge: 'spotify-api#Spotify#Object.AlbumSimplified',
           CurrentlyPlaying: 'spotify-api#Spotify#Object.CurrentlyPlaying',
           CurrentUser: 'spotify-api#Spotify#Object.CurrentUser',
+          CurrentUserProfile: 'spotify-api#Spotify#Object.CurrentUser',
           Developer: '{}',
           Device: 'spotify-api#Spotify#Object.Device',
           Episode:
             'spotify-api#Spotify#Object.Episode | Spotify.Object.EpisodeSimplified',
+          ExplicitContentSettings:
+            'spotify-api#Spotify#Object.ExplicitContentSettings',
           FeaturedPlaylistConnection:
             'spotify-api#Spotify#Object.FeaturedPlaylists',
           FeaturedPlaylistEdge: 'spotify-api#Spotify#Object.PlaylistSimplified',

--- a/shared/spotify-api/src/constants.ts
+++ b/shared/spotify-api/src/constants.ts
@@ -11,6 +11,7 @@ export const OAUTH_SCOPES = [
   'user-read-currently-playing',
   'user-read-playback-position',
   'user-read-playback-state',
+  'user-read-private',
   'user-library-read',
   'user-library-modify',
   'user-top-read',

--- a/shared/spotify-api/src/mockClient.ts
+++ b/shared/spotify-api/src/mockClient.ts
@@ -308,12 +308,18 @@ export class MockSpotifyClient implements SpotifyDataSource {
     return {
       id: this.userId,
       display_name: 'GraphOS User',
+      country: process.env.DEFAULT_COUNTRY_CODE || 'US',
       email: 'contact@apollographql.com',
       external_urls: { spotify: '' },
+      explicit_content: {
+        filter_enabled: false,
+        filter_locked: false,
+      },
       followers: { href: '', total: 1000000 },
       href: '',
       images: [],
       uri: 'https://discord.gg/graphos',
+      product: 'free',
       type: 'user',
     };
   }

--- a/shared/spotify-api/src/types.ts
+++ b/shared/spotify-api/src/types.ts
@@ -138,14 +138,11 @@ export namespace Spotify {
     export type CurrentlyPlayingType = 'track' | 'episode' | 'ad' | 'unknown';
 
     export interface CurrentUser {
-      country?: RestrictScope<string, 'user-read-private'>;
+      country: RestrictScope<string, 'user-read-private'>;
       display_name: string | null;
       email: RestrictScope<string, 'user-read-email'>;
-      explicit_content?: RestrictScope<
-        {
-          filter_enabled: boolean;
-          filter_locked: boolean;
-        },
+      explicit_content: RestrictScope<
+        ExplicitContentSettings,
         'user-read-private'
       >;
       external_urls: ExternalUrl;
@@ -153,7 +150,7 @@ export namespace Spotify {
       href: string;
       id: string;
       images: Image[];
-      product?: RestrictScope<string, 'user-read-private'>;
+      product: RestrictScope<string, 'user-read-private'>;
       type: 'user';
       uri: string;
     }
@@ -227,6 +224,11 @@ export namespace Spotify {
       resume_point: RestrictScope<ResumePoint, 'user-read-playback-position'>;
       type: 'episode';
       uri: string;
+    }
+
+    export interface ExplicitContentSettings {
+      filter_enabled: boolean;
+      filter_locked: boolean;
     }
 
     export type ExternalId = Record<string, string>;

--- a/subgraphs/spotify/schema.graphql
+++ b/subgraphs/spotify/schema.graphql
@@ -749,7 +749,7 @@ type CurrentUser {
   """
   user: User!
     @deprecated(
-      reason: "Use the profile field instead which provides richer user information."
+      reason: "Use the profile field instead which provides richer current user information."
     )
 
   """

--- a/subgraphs/spotify/schema.graphql
+++ b/subgraphs/spotify/schema.graphql
@@ -748,6 +748,9 @@ type CurrentUser {
   Detailed profile information about the current user.
   """
   user: User!
+    @deprecated(
+      reason: "Use the profile field instead which provides richer user information."
+    )
 
   """
   Information about the user's current playback state
@@ -770,6 +773,11 @@ type CurrentUser {
     """
     offset: Int
   ): PlaylistConnection
+
+  """
+  Get detailed profile information about the current user (including the current user's username).
+  """
+  profile: CurrentUserProfile!
 
   """
   Get a list of the albums saved in the current Spotify user's 'Your Music' library.
@@ -863,6 +871,64 @@ type CurrentUser {
     """
     ids: [ID!]!
   ): [Boolean!]
+}
+
+type CurrentUserProfile {
+  """
+  The country of the user, as set in the user's account profile. An ISO 3166-1
+  alpha-2 country code.
+  """
+  country: CountryCode!
+
+  """
+  The name displayed on the user's profile. `null` if not available.
+  """
+  displayName: String
+
+  """
+  The user's email address, as entered by the user when creating their account.
+  _**Important!** This email address is unverified; there is no proof that it
+  actually belongs to the user._
+  """
+  email: String!
+
+  """
+  The user's explicit content settings.
+  """
+  explicitContent: ExplicitContentSettings!
+
+  """
+  Information about the followers of the user.
+  """
+  followers: Followers!
+
+  """
+  A link to the Web API endpoint for this user.
+  """
+  href: String!
+
+  """
+  The [Spotify user ID](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids)
+  for the user.
+  """
+  id: ID!
+
+  """
+  The user's profile image.
+  """
+  images: [Image!]!
+
+  """
+  The user's Spotify subscription level: "premium", "free", etc. (The
+  subscription level "open" can be considered the same as "free".)
+  """
+  product: String!
+
+  """
+  The [Spotify URI](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids)
+  for the user.
+  """
+  uri: String!
 }
 
 type Developer {
@@ -987,6 +1053,19 @@ type Episode implements PlaylistTrack & PlaybackItem @key(fields: "id") {
   for the episode.
   """
   uri: String! @shareable
+}
+
+type ExplicitContentSettings {
+  """
+  When `true`, indicates that explicit content should not be played.
+  """
+  filterEnabled: Boolean!
+
+  """
+  When `true`, indicates that the explicit content setting is locked and can't
+  be changed by the user.
+  """
+  filterLocked: Boolean!
 }
 
 type ExternalUrl @shareable {

--- a/subgraphs/spotify/src/__generated__/resolvers-types.ts
+++ b/subgraphs/spotify/src/__generated__/resolvers-types.ts
@@ -303,6 +303,8 @@ export type CurrentUser = {
   player: Player;
   /** Playlists owned or followed by the current Spotify user. */
   playlists?: Maybe<PlaylistConnection>;
+  /** Get detailed profile information about the current user (including the current user's username). */
+  profile: CurrentUserProfile;
   /** Get a list of the albums saved in the current Spotify user's 'Your Music' library. */
   shows?: Maybe<SavedShowsConnection>;
   /**
@@ -320,7 +322,10 @@ export type CurrentUser = {
    * 'Your Music' library.
    */
   tracksContains?: Maybe<Array<Scalars['Boolean']['output']>>;
-  /** Detailed profile information about the current user. */
+  /**
+   * Detailed profile information about the current user.
+   * @deprecated Use the profile field instead which provides richer user information.
+   */
   user: User;
 };
 
@@ -380,6 +385,46 @@ export type CurrentUserTracksArgs = {
 
 export type CurrentUserTracksContainsArgs = {
   ids: Array<Scalars['ID']['input']>;
+};
+
+export type CurrentUserProfile = {
+  __typename?: 'CurrentUserProfile';
+  /**
+   * The country of the user, as set in the user's account profile. An ISO 3166-1
+   * alpha-2 country code.
+   */
+  country: Scalars['CountryCode']['output'];
+  /** The name displayed on the user's profile. `null` if not available. */
+  displayName?: Maybe<Scalars['String']['output']>;
+  /**
+   * The user's email address, as entered by the user when creating their account.
+   * _**Important!** This email address is unverified; there is no proof that it
+   * actually belongs to the user._
+   */
+  email: Scalars['String']['output'];
+  /** The user's explicit content settings. */
+  explicitContent: ExplicitContentSettings;
+  /** Information about the followers of the user. */
+  followers: Followers;
+  /** A link to the Web API endpoint for this user. */
+  href: Scalars['String']['output'];
+  /**
+   * The [Spotify user ID](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids)
+   * for the user.
+   */
+  id: Scalars['ID']['output'];
+  /** The user's profile image. */
+  images: Array<Image>;
+  /**
+   * The user's Spotify subscription level: "premium", "free", etc. (The
+   * subscription level "open" can be considered the same as "free".)
+   */
+  product: Scalars['String']['output'];
+  /**
+   * The [Spotify URI](https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids)
+   * for the user.
+   */
+  uri: Scalars['String']['output'];
 };
 
 export type CurrentlyPlaying = {
@@ -497,6 +542,17 @@ export type Episode = PlaybackItem &
 /** Spotify catalog information for an episode. */
 export type EpisodeDescriptionArgs = {
   format?: InputMaybe<TextFormat>;
+};
+
+export type ExplicitContentSettings = {
+  __typename?: 'ExplicitContentSettings';
+  /** When `true`, indicates that explicit content should not be played. */
+  filterEnabled: Scalars['Boolean']['output'];
+  /**
+   * When `true`, indicates that the explicit content setting is locked and can't
+   * be changed by the user.
+   */
+  filterLocked: Scalars['Boolean']['output'];
 };
 
 export type ExternalUrl = {
@@ -2034,6 +2090,7 @@ export type ResolversTypes = ResolversObject<{
   CopyrightType: CopyrightType;
   CountryCode: ResolverTypeWrapper<Scalars['CountryCode']['output']>;
   CurrentUser: ResolverTypeWrapper<Spotify.Object.CurrentUser>;
+  CurrentUserProfile: ResolverTypeWrapper<CurrentUserProfile>;
   CurrentlyPlaying: ResolverTypeWrapper<Spotify.Object.CurrentlyPlaying>;
   Cursors: ResolverTypeWrapper<Cursors>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
@@ -2043,6 +2100,7 @@ export type ResolversTypes = ResolversObject<{
     Spotify.Object.Episode | Spotify.Object.EpisodeSimplified
   >;
   ErrorRate: ResolverTypeWrapper<Scalars['ErrorRate']['output']>;
+  ExplicitContentSettings: ResolverTypeWrapper<ExplicitContentSettings>;
   ExternalUrl: ResolverTypeWrapper<ExternalUrl>;
   FeaturedPlaylistConnection: ResolverTypeWrapper<Spotify.Object.FeaturedPlaylists>;
   FeaturedPlaylistEdge: ResolverTypeWrapper<Spotify.Object.PlaylistSimplified>;
@@ -2276,6 +2334,7 @@ export type ResolversParentTypes = ResolversObject<{
   Copyright: Copyright;
   CountryCode: Scalars['CountryCode']['output'];
   CurrentUser: Spotify.Object.CurrentUser;
+  CurrentUserProfile: CurrentUserProfile;
   CurrentlyPlaying: Spotify.Object.CurrentlyPlaying;
   Cursors: Cursors;
   DateTime: Scalars['DateTime']['output'];
@@ -2283,6 +2342,7 @@ export type ResolversParentTypes = ResolversObject<{
   Device: Spotify.Object.Device;
   Episode: Spotify.Object.Episode | Spotify.Object.EpisodeSimplified;
   ErrorRate: Scalars['ErrorRate']['output'];
+  ExplicitContentSettings: ExplicitContentSettings;
   ExternalUrl: ExternalUrl;
   FeaturedPlaylistConnection: Spotify.Object.FeaturedPlaylists;
   FeaturedPlaylistEdge: Spotify.Object.PlaylistSimplified;
@@ -2711,6 +2771,11 @@ export type CurrentUserResolvers<
     ContextType,
     Partial<CurrentUserPlaylistsArgs>
   >;
+  profile?: Resolver<
+    ResolversTypes['CurrentUserProfile'],
+    ParentType,
+    ContextType
+  >;
   shows?: Resolver<
     Maybe<ResolversTypes['SavedShowsConnection']>,
     ParentType,
@@ -2748,6 +2813,32 @@ export type CurrentUserResolvers<
     RequireFields<CurrentUserTracksContainsArgs, 'ids'>
   >;
   user?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type CurrentUserProfileResolvers<
+  ContextType = ContextValue,
+  ParentType extends
+    ResolversParentTypes['CurrentUserProfile'] = ResolversParentTypes['CurrentUserProfile'],
+> = ResolversObject<{
+  country?: Resolver<ResolversTypes['CountryCode'], ParentType, ContextType>;
+  displayName?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  explicitContent?: Resolver<
+    ResolversTypes['ExplicitContentSettings'],
+    ParentType,
+    ContextType
+  >;
+  followers?: Resolver<ResolversTypes['Followers'], ParentType, ContextType>;
+  href?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  images?: Resolver<Array<ResolversTypes['Image']>, ParentType, ContextType>;
+  product?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  uri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -2882,6 +2973,16 @@ export interface ErrorRateScalarConfig
   extends GraphQLScalarTypeConfig<ResolversTypes['ErrorRate'], any> {
   name: 'ErrorRate';
 }
+
+export type ExplicitContentSettingsResolvers<
+  ContextType = ContextValue,
+  ParentType extends
+    ResolversParentTypes['ExplicitContentSettings'] = ResolversParentTypes['ExplicitContentSettings'],
+> = ResolversObject<{
+  filterEnabled?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  filterLocked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
 
 export type ExternalUrlResolvers<
   ContextType = ContextValue,
@@ -4255,6 +4356,7 @@ export type Resolvers<ContextType = ContextValue> = ResolversObject<{
   Copyright?: CopyrightResolvers<ContextType>;
   CountryCode?: GraphQLScalarType;
   CurrentUser?: CurrentUserResolvers<ContextType>;
+  CurrentUserProfile?: CurrentUserProfileResolvers<ContextType>;
   CurrentlyPlaying?: CurrentlyPlayingResolvers<ContextType>;
   Cursors?: CursorsResolvers<ContextType>;
   DateTime?: GraphQLScalarType;
@@ -4262,6 +4364,7 @@ export type Resolvers<ContextType = ContextValue> = ResolversObject<{
   Device?: DeviceResolvers<ContextType>;
   Episode?: EpisodeResolvers<ContextType>;
   ErrorRate?: GraphQLScalarType;
+  ExplicitContentSettings?: ExplicitContentSettingsResolvers<ContextType>;
   ExternalUrl?: ExternalUrlResolvers<ContextType>;
   FeaturedPlaylistConnection?: FeaturedPlaylistConnectionResolvers<ContextType>;
   FeaturedPlaylistEdge?: FeaturedPlaylistEdgeResolvers<ContextType>;

--- a/subgraphs/spotify/src/__generated__/resolvers-types.ts
+++ b/subgraphs/spotify/src/__generated__/resolvers-types.ts
@@ -2090,7 +2090,7 @@ export type ResolversTypes = ResolversObject<{
   CopyrightType: CopyrightType;
   CountryCode: ResolverTypeWrapper<Scalars['CountryCode']['output']>;
   CurrentUser: ResolverTypeWrapper<Spotify.Object.CurrentUser>;
-  CurrentUserProfile: ResolverTypeWrapper<CurrentUserProfile>;
+  CurrentUserProfile: ResolverTypeWrapper<Spotify.Object.CurrentUser>;
   CurrentlyPlaying: ResolverTypeWrapper<Spotify.Object.CurrentlyPlaying>;
   Cursors: ResolverTypeWrapper<Cursors>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
@@ -2100,7 +2100,7 @@ export type ResolversTypes = ResolversObject<{
     Spotify.Object.Episode | Spotify.Object.EpisodeSimplified
   >;
   ErrorRate: ResolverTypeWrapper<Scalars['ErrorRate']['output']>;
-  ExplicitContentSettings: ResolverTypeWrapper<ExplicitContentSettings>;
+  ExplicitContentSettings: ResolverTypeWrapper<Spotify.Object.ExplicitContentSettings>;
   ExternalUrl: ResolverTypeWrapper<ExternalUrl>;
   FeaturedPlaylistConnection: ResolverTypeWrapper<Spotify.Object.FeaturedPlaylists>;
   FeaturedPlaylistEdge: ResolverTypeWrapper<Spotify.Object.PlaylistSimplified>;
@@ -2334,7 +2334,7 @@ export type ResolversParentTypes = ResolversObject<{
   Copyright: Copyright;
   CountryCode: Scalars['CountryCode']['output'];
   CurrentUser: Spotify.Object.CurrentUser;
-  CurrentUserProfile: CurrentUserProfile;
+  CurrentUserProfile: Spotify.Object.CurrentUser;
   CurrentlyPlaying: Spotify.Object.CurrentlyPlaying;
   Cursors: Cursors;
   DateTime: Scalars['DateTime']['output'];
@@ -2342,7 +2342,7 @@ export type ResolversParentTypes = ResolversObject<{
   Device: Spotify.Object.Device;
   Episode: Spotify.Object.Episode | Spotify.Object.EpisodeSimplified;
   ErrorRate: Scalars['ErrorRate']['output'];
-  ExplicitContentSettings: ExplicitContentSettings;
+  ExplicitContentSettings: Spotify.Object.ExplicitContentSettings;
   ExternalUrl: ExternalUrl;
   FeaturedPlaylistConnection: Spotify.Object.FeaturedPlaylists;
   FeaturedPlaylistEdge: Spotify.Object.PlaylistSimplified;

--- a/subgraphs/spotify/src/resolvers/CurrentUser.ts
+++ b/subgraphs/spotify/src/resolvers/CurrentUser.ts
@@ -41,6 +41,7 @@ export const CurrentUser: CurrentUserResolvers = {
       offset: args.offset ?? undefined,
     });
   },
+  profile: itself(),
   shows: (_, { limit, offset }, { dataSources }) => {
     return dataSources.spotify.getSavedShows({
       limit: maybe(limit),

--- a/subgraphs/spotify/src/resolvers/CurrentUserProfile.ts
+++ b/subgraphs/spotify/src/resolvers/CurrentUserProfile.ts
@@ -1,0 +1,7 @@
+import { CurrentUserProfileResolvers } from '../__generated__/resolvers-types';
+import { prop } from './helpers';
+
+export const CurrentUserProfile: CurrentUserProfileResolvers = {
+  displayName: prop('display_name'),
+  explicitContent: prop('explicit_content'),
+};

--- a/subgraphs/spotify/src/resolvers/ExplicitContentSettings.ts
+++ b/subgraphs/spotify/src/resolvers/ExplicitContentSettings.ts
@@ -1,0 +1,7 @@
+import { ExplicitContentSettingsResolvers } from '../__generated__/resolvers-types';
+import { prop } from './helpers';
+
+export const ExplicitContentSettings: ExplicitContentSettingsResolvers = {
+  filterEnabled: prop('filter_enabled'),
+  filterLocked: prop('filter_locked'),
+};

--- a/subgraphs/spotify/src/resolvers/index.ts
+++ b/subgraphs/spotify/src/resolvers/index.ts
@@ -11,12 +11,14 @@ import { ArtistAlbumEdge } from './ArtistAlbumEdge';
 import { ArtistAlbumsConnection } from './ArtistAlbumsConnection';
 import { CountryCode } from './CountryCode';
 import { CurrentUser } from './CurrentUser';
+import { CurrentUserProfile } from './CurrentUserProfile';
 import { CurrentlyPlaying } from './CurrentlyPlaying';
 import { DateTime } from './DateTime';
 import { Developer } from './Developer';
 import { Device } from './Device';
 import { Episode } from './Episode';
 import { ErrorRate } from './ErrorRate';
+import { ExplicitContentSettings } from './ExplicitContentSettings';
 import { FeaturedPlaylistConnection } from './FeaturedPlaylistConnection';
 import { FeaturedPlaylistEdge } from './FeaturedPlaylistEdge';
 import { FieldConfig } from './FieldConfig';
@@ -98,11 +100,13 @@ const actualResolvers = {
   CountryCode,
   CurrentlyPlaying,
   CurrentUser,
+  CurrentUserProfile,
   DateTime,
   Developer,
   Device,
   Episode,
   ErrorRate,
+  ExplicitContentSettings,
   FeaturedPlaylistConnection,
   FeaturedPlaylistEdge,
   FieldConfig,


### PR DESCRIPTION
The `user` field on the `CurrentUser` type previously returned a `User` type, which is limited in the information returned. Spotify adds additional fields when requesting the current user's profile. This PR adds a new `profile` field on the `CurrentUser` type which returns a new `CurrentUserProfile` type that includes the additional information. 