### PR TITLE
Add a shade color for suspense highlights

### DIFF
--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -1,25 +1,49 @@
-import { cloneElement, Fragment, ReactNode } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
 
 interface LoadingStateHighlighterProps {
   children: ReactNode;
+  shade?: string;
+}
+
+interface OverlayStyleProps extends CSSProperties {
+  '--shade': string;
+}
+
+interface ContainerSyleProps extends CSSProperties {
+  '--border-color': string;
 }
 
 const LoadingStateHighlighter = ({
   children,
+  shade,
 }: LoadingStateHighlighterProps) => {
   const highlightSuspenseBoundaries = useReactiveVar(
     highlightSuspenseBoundariesVar
   );
 
-  return cloneElement(
-    highlightSuspenseBoundaries ? (
-      <div className="[&>*]:border-2 [&>*]:border-suspense-boundary" />
-    ) : (
-      <Fragment />
-    ),
-    { children }
+  return highlightSuspenseBoundaries ? (
+    <div className="relative overflow-hidden">
+      <div
+        className="border-4 border-[var(--border-color)] absolute inset-0 z-50"
+        style={
+          {
+            '--border-color': shade || 'red',
+          } as ContainerSyleProps
+        }
+      >
+        {shade && (
+          <div
+            className="absolute inset-0 opacity-25 bg-[var(--shade)]"
+            style={{ '--shade': shade } as OverlayStyleProps}
+          />
+        )}
+      </div>
+      {children}
+    </div>
+  ) : (
+    children
   );
 };
 

--- a/client/src/components/Suspense.tsx
+++ b/client/src/components/Suspense.tsx
@@ -1,13 +1,21 @@
-import React, { SuspenseProps } from 'react';
+import React, { SuspenseProps as ReactSuspenseProps } from 'react';
 import LoadingStateHighlighter from './LoadingStateHighlighter';
+
+interface SuspenseProps extends ReactSuspenseProps {
+  shade?: string;
+}
 
 // A decorated <Suspense /> component that will highlight the loading state when
 // the "Highlight Suspense Boundaries" setting is enabled.
-const Suspense = ({ fallback, ...props }: SuspenseProps) => {
+const Suspense = ({ fallback, shade, ...props }: SuspenseProps) => {
   return (
     <React.Suspense
       {...props}
-      fallback={<LoadingStateHighlighter>{fallback}</LoadingStateHighlighter>}
+      fallback={
+        <LoadingStateHighlighter shade={shade}>
+          {fallback}
+        </LoadingStateHighlighter>
+      }
     />
   );
 };


### PR DESCRIPTION
To make some suspense boundaries more obvious, this allows for a `shade` prop that can be used to highlight a suspendable area.

<img width="1920" alt="loading" src="https://github.com/apollographql/spotify-showcase/assets/565661/353867b5-19c5-4f39-8c11-b723af53163b">
