### PR TITLE
Write updated refresh token after getting new access token

### DIFF
--- a/client/src/auth.ts
+++ b/client/src/auth.ts
@@ -42,6 +42,7 @@ export const refreshSession = (response: RefreshAccessTokenResponse) => {
   const expiresAt = now.setSeconds(now.getSeconds() + response.expires_in);
 
   writeToken('access', response.access_token);
+  writeToken('refresh', response.refresh_token);
   localStorage.setItem(STORAGE_KEYS.EXPIRES_AT, String(expiresAt));
 };
 

--- a/client/src/utils/oauth.ts
+++ b/client/src/utils/oauth.ts
@@ -15,6 +15,7 @@ export interface AccessTokenResponse {
 export interface RefreshAccessTokenResponse {
   access_token: string;
   token_type: 'Bearer';
+  refresh_token: string;
   scope: string;
   expires_in: number;
 }


### PR DESCRIPTION
With the PKCE extension to the OAuth flow, refresh tokens are only valid for refreshing an access token once. https://community.spotify.com/t5/Spotify-for-Developers/Refreshing-tokens-for-PKCE-authorised-users/m-p/5023175

When refreshing the access token, a new refresh token is given for the next request. This ensures the updated refresh token is saved to keep the user logged in.