### PR TITLE
More robust loading highlight

### DIFF
--- a/client/src/components/LoadingStateBackdrop.tsx
+++ b/client/src/components/LoadingStateBackdrop.tsx
@@ -1,6 +1,8 @@
 import { CSSProperties, ReactNode } from 'react';
+import cx from 'classnames';
 
 interface LoadingStateBackdropProps {
+  className?: string;
   shade: string;
   children?: ReactNode;
 }
@@ -14,11 +16,12 @@ interface ContainerSyleProps extends CSSProperties {
 }
 
 const LoadingStateBackdrop = ({
+  className,
   children,
   shade,
 }: LoadingStateBackdropProps) => {
   return (
-    <div className="relative overflow-hidden">
+    <div className={cx(className, 'relative overflow-hidden')}>
       <div
         className="border-4 border-[var(--border-color)] absolute inset-0 z-50"
         style={

--- a/client/src/components/LoadingStateBackdrop.tsx
+++ b/client/src/components/LoadingStateBackdrop.tsx
@@ -1,0 +1,40 @@
+import { CSSProperties, ReactNode } from 'react';
+
+interface LoadingStateBackdropProps {
+  shade: string;
+  children?: ReactNode;
+}
+
+interface OverlayStyleProps extends CSSProperties {
+  '--shade': string;
+}
+
+interface ContainerSyleProps extends CSSProperties {
+  '--border-color': string;
+}
+
+const LoadingStateBackdrop = ({
+  children,
+  shade,
+}: LoadingStateBackdropProps) => {
+  return (
+    <div className="relative overflow-hidden">
+      <div
+        className="border-4 border-[var(--border-color)] absolute inset-0 z-50"
+        style={
+          {
+            '--border-color': shade,
+          } as ContainerSyleProps
+        }
+      >
+        <div
+          className="absolute inset-0 opacity-25 bg-[var(--shade)]"
+          style={{ '--shade': shade } as OverlayStyleProps}
+        />
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default LoadingStateBackdrop;

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -8,6 +8,7 @@ interface LoadingStateHighlighterProps {
 }
 
 interface HighlightConfig {
+  className?: string;
   shade: string;
 }
 
@@ -27,7 +28,9 @@ const LoadingStateHighlighter = ({
       : defaultConfig;
 
   return highlightSuspenseBoundaries ? (
-    <LoadingStateBackdrop shade={config.shade}>{children}</LoadingStateBackdrop>
+    <LoadingStateBackdrop className={config.className} shade={config.shade}>
+      {children}
+    </LoadingStateBackdrop>
   ) : (
     children
   );
@@ -45,18 +48,20 @@ interface HighlightableComponent<TProps> {
 }
 
 interface Options {
+  className?: string;
   shade?: string;
 }
 
 export function withHighlight<TProps = unknown>(
   LoadingState: (props: TProps) => ReactNode,
-  { shade = 'red' }: Options = {}
+  { className, shade = 'red' }: Options = {}
 ): HighlightableComponent<TProps> {
   const LoadingStateWithHighlight =
     LoadingState as HighlightableComponent<TProps>;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (LoadingStateWithHighlight as any).__highlight = {
+    className,
     shade,
   };
 

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
+import { CSSProperties, ElementType, ReactNode } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
 
@@ -45,6 +45,12 @@ const LoadingStateHighlighter = ({
   ) : (
     children
   );
+};
+
+export const withHighlight = (LoadingState: ElementType) => {
+  return function DecoratedLoadingState() {
+    return <LoadingState />;
+  };
 };
 
 export default LoadingStateHighlighter;

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -1,10 +1,15 @@
-import { CSSProperties, ElementType, ReactNode } from 'react';
+import {
+  Children,
+  CSSProperties,
+  ElementType,
+  ReactNode,
+  isValidElement,
+} from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
 
 interface LoadingStateHighlighterProps {
   children: ReactNode;
-  shade?: string;
 }
 
 interface OverlayStyleProps extends CSSProperties {
@@ -15,13 +20,26 @@ interface ContainerSyleProps extends CSSProperties {
   '--border-color': string;
 }
 
+const isHighlighted = (
+  element: JSX.ElementType
+): element is HighlightableComponent<unknown> => {
+  return typeof element !== 'string' && '__highlight' in element;
+};
+
+const defaultConfig = { shade: 'red' };
+
 const LoadingStateHighlighter = ({
   children,
-  shade,
 }: LoadingStateHighlighterProps) => {
   const highlightSuspenseBoundaries = useReactiveVar(
     highlightSuspenseBoundariesVar
   );
+
+  const element = Children.only(children);
+  const config =
+    isValidElement(element) && isHighlighted(element.type)
+      ? element.type.__highlight
+      : defaultConfig;
 
   return highlightSuspenseBoundaries ? (
     <div className="relative overflow-hidden">
@@ -29,16 +47,14 @@ const LoadingStateHighlighter = ({
         className="border-4 border-[var(--border-color)] absolute inset-0 z-50"
         style={
           {
-            '--border-color': shade || 'red',
+            '--border-color': config.shade,
           } as ContainerSyleProps
         }
       >
-        {shade && (
-          <div
-            className="absolute inset-0 opacity-25 bg-[var(--shade)]"
-            style={{ '--shade': shade } as OverlayStyleProps}
-          />
-        )}
+        <div
+          className="absolute inset-0 opacity-25 bg-[var(--shade)]"
+          style={{ '--shade': config.shade } as OverlayStyleProps}
+        />
       </div>
       {children}
     </div>
@@ -47,10 +63,31 @@ const LoadingStateHighlighter = ({
   );
 };
 
-export const withHighlight = (LoadingState: ElementType) => {
-  return function DecoratedLoadingState() {
-    return <LoadingState />;
+interface HighlightableComponent<TProps> {
+  (props: TProps): ReactNode;
+  readonly __highlight: {
+    shade: string;
   };
-};
+}
+
+interface Options {
+  shade?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function withHighlight<TProps = unknown>(
+  LoadingState: (props: TProps) => ReactNode,
+  { shade = 'red' }: Options = {}
+): HighlightableComponent<TProps> {
+  const LoadingStateWithHighlight =
+    LoadingState as HighlightableComponent<TProps>;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (LoadingStateWithHighlight as any).__highlight = {
+    shade,
+  };
+
+  return LoadingStateWithHighlight;
+}
 
 export default LoadingStateHighlighter;

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -1,10 +1,4 @@
-import {
-  Children,
-  CSSProperties,
-  ElementType,
-  ReactNode,
-  isValidElement,
-} from 'react';
+import { Children, CSSProperties, ReactNode, isValidElement } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
 
@@ -26,7 +20,11 @@ const isHighlighted = (
   return typeof element !== 'string' && '__highlight' in element;
 };
 
-const defaultConfig = { shade: 'red' };
+interface HighlightConfig {
+  shade: string;
+}
+
+const defaultConfig: HighlightConfig = { shade: 'red' };
 
 const LoadingStateHighlighter = ({
   children,
@@ -65,9 +63,7 @@ const LoadingStateHighlighter = ({
 
 interface HighlightableComponent<TProps> {
   (props: TProps): ReactNode;
-  readonly __highlight: {
-    shade: string;
-  };
+  readonly __highlight: HighlightConfig;
 }
 
 interface Options {

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -1,24 +1,11 @@
-import { Children, CSSProperties, ReactNode, isValidElement } from 'react';
+import { Children, ReactNode, isValidElement } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
+import LoadingStateBackdrop from './LoadingStateBackdrop';
 
 interface LoadingStateHighlighterProps {
   children: ReactNode;
 }
-
-interface OverlayStyleProps extends CSSProperties {
-  '--shade': string;
-}
-
-interface ContainerSyleProps extends CSSProperties {
-  '--border-color': string;
-}
-
-const isHighlighted = (
-  element: JSX.ElementType
-): element is HighlightableComponent<unknown> => {
-  return typeof element !== 'string' && '__highlight' in element;
-};
 
 interface HighlightConfig {
   shade: string;
@@ -40,25 +27,16 @@ const LoadingStateHighlighter = ({
       : defaultConfig;
 
   return highlightSuspenseBoundaries ? (
-    <div className="relative overflow-hidden">
-      <div
-        className="border-4 border-[var(--border-color)] absolute inset-0 z-50"
-        style={
-          {
-            '--border-color': config.shade,
-          } as ContainerSyleProps
-        }
-      >
-        <div
-          className="absolute inset-0 opacity-25 bg-[var(--shade)]"
-          style={{ '--shade': config.shade } as OverlayStyleProps}
-        />
-      </div>
-      {children}
-    </div>
+    <LoadingStateBackdrop shade={config.shade}>{children}</LoadingStateBackdrop>
   ) : (
     children
   );
+};
+
+const isHighlighted = (
+  element: JSX.ElementType
+): element is HighlightableComponent<unknown> => {
+  return typeof element !== 'string' && '__highlight' in element;
 };
 
 interface HighlightableComponent<TProps> {
@@ -70,7 +48,6 @@ interface Options {
   shade?: string;
 }
 
-// eslint-disable-next-line @typescript-eslint/ban-types
 export function withHighlight<TProps = unknown>(
   LoadingState: (props: TProps) => ReactNode,
   { shade = 'red' }: Options = {}

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -24,12 +24,12 @@ import { withHighlight } from './LoadingStateHighlighter';
 
 const LoggedInLayout = () => {
   return (
-    <Suspense shade="#67EEF0" fallback={<LoadingState />}>
+    <Suspense fallback={<LoadingState />}>
       <Container>
         <Sidebar />
         <Main>
           <Header />
-          <Suspense shade="#FF2600" fallback={<StandardLoadingState />}>
+          <Suspense fallback={<StandardLoadingState />}>
             <Outlet />
           </Suspense>
         </Main>
@@ -218,19 +218,22 @@ const Container = ({ children }: ContainerProps) => {
   );
 };
 
-const LoadingState = withHighlight(() => {
-  return (
-    <Layout type="player">
-      <SidebarLoadingState />
-      <Layout.Main>
-        <header className="flex items-center justify-end text-primary bg-transparent pt-[var(--main-content--padding)] px-[var(--main-content--padding)] absolute top-0 w-full pointer-events-none flex-shrink-0 z-10">
-          <CurrentUserMenuLoadingState />
-        </header>
-        <StandardLoadingState />
-      </Layout.Main>
-      <PlaybarLoadingState />
-    </Layout>
-  );
-});
+const LoadingState = withHighlight(
+  () => {
+    return (
+      <Layout type="player">
+        <SidebarLoadingState />
+        <Layout.Main>
+          <header className="flex items-center justify-end text-primary bg-transparent pt-[var(--main-content--padding)] px-[var(--main-content--padding)] absolute top-0 w-full pointer-events-none flex-shrink-0 z-10">
+            <CurrentUserMenuLoadingState />
+          </header>
+          <StandardLoadingState />
+        </Layout.Main>
+        <PlaybarLoadingState />
+      </Layout>
+    );
+  },
+  { shade: '#67EEF0' }
+);
 
 export default LoggedInLayout;

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -20,6 +20,7 @@ import CurrentUserMenu, {
 } from './CurrentUserMenu';
 import Suspense from './Suspense';
 import StandardLoadingState from './StandardLoadingState';
+import { withHighlight } from './LoadingStateHighlighter';
 
 const LoggedInLayout = () => {
   return (
@@ -217,7 +218,7 @@ const Container = ({ children }: ContainerProps) => {
   );
 };
 
-const LoadingState = () => {
+const LoadingState = withHighlight(() => {
   return (
     <Layout type="player">
       <SidebarLoadingState />
@@ -230,6 +231,6 @@ const LoadingState = () => {
       <PlaybarLoadingState />
     </Layout>
   );
-};
+});
 
 export default LoggedInLayout;

--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -32,6 +32,7 @@ import QueueControlButton from './QueueControlButton';
 import { fragmentRegistry } from '../apollo/fragmentRegistry';
 import Skeleton from './Skeleton';
 import LikeButton from './LikeButton';
+import { withHighlight } from './LoadingStateHighlighter';
 
 const EPISODE_SKIP_FORWARD_AMOUNT = 15_000;
 
@@ -212,47 +213,50 @@ const Playbar = () => {
   );
 };
 
-export const LoadingState = () => {
-  return (
-    <footer className="[grid-area:playbar] flex flex-col">
-      <div className="items-center grid grid-cols-[30%_1fr_30%] text-primary py-5 px-6">
-        <div className="flex items-center gap-4">
-          <Skeleton.CoverPhoto size="4rem" />
+export const LoadingState = withHighlight(
+  () => {
+    return (
+      <footer className="[grid-area:playbar] flex flex-col">
+        <div className="items-center grid grid-cols-[30%_1fr_30%] text-primary py-5 px-6">
+          <div className="flex items-center gap-4">
+            <Skeleton.CoverPhoto size="4rem" />
+            <div className="flex flex-col gap-2">
+              <Skeleton.Text width="4rem" />
+              <Skeleton.Text width="8rem" />
+            </div>
+            <LikeButton disabled liked={false} />
+          </div>
           <div className="flex flex-col gap-2">
-            <Skeleton.Text width="4rem" />
-            <Skeleton.Text width="8rem" />
+            <div className="flex items-center gap-5 justify-center">
+              <ShufflePlaybackControl
+                disallowed
+                size="1.25rem"
+                shuffled={false}
+              />
+              <SkipToPreviousControl disallowed progressMs={0} />
+              <PlayButton disabled playing={false} size="2.5rem" />
+              <SkipToNextControl disallowed />
+              <RepeatControl disallowed repeatState={RepeatMode.Off} />
+            </div>
+            <PlaybackItemProgressBar playbackState={null} />
           </div>
-          <LikeButton disabled liked={false} />
-        </div>
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center gap-5 justify-center">
-            <ShufflePlaybackControl
+          <div className="flex justify-end gap-4 items-center">
+            <QueueControlButton />
+            <PlaybarControlButton
               disallowed
-              size="1.25rem"
-              shuffled={false}
+              icon={<DeviceIcon device={undefined} strokeWidth={1.5} />}
+              tooltip="Connect to a device"
             />
-            <SkipToPreviousControl disallowed progressMs={0} />
-            <PlayButton disabled playing={false} size="2.5rem" />
-            <SkipToNextControl disallowed />
-            <RepeatControl disallowed repeatState={RepeatMode.Off} />
-          </div>
-          <PlaybackItemProgressBar playbackState={null} />
-        </div>
-        <div className="flex justify-end gap-4 items-center">
-          <QueueControlButton />
-          <PlaybarControlButton
-            disallowed
-            icon={<DeviceIcon device={undefined} strokeWidth={1.5} />}
-            tooltip="Connect to a device"
-          />
-          <div className="flex gap-2 items-center">
-            <MuteControl disallowed volumePercent={100} />
-            <VolumeBar volumePercent={100} width="100px" />
+            <div className="flex gap-2 items-center">
+              <MuteControl disallowed volumePercent={100} />
+              <VolumeBar volumePercent={100} width="100px" />
+            </div>
           </div>
         </div>
-      </div>
-    </footer>
-  );
-};
+      </footer>
+    );
+  },
+  { shade: '#0433FF' }
+);
 
 export default Playbar;

--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -256,7 +256,7 @@ export const LoadingState = withHighlight(
       </footer>
     );
   },
-  { shade: '#0433FF' }
+  { className: '[grid-area:playbar] flex flex-col', shade: '#0433FF' }
 );
 
 export default Playbar;

--- a/client/src/components/StandardLoadingState.tsx
+++ b/client/src/components/StandardLoadingState.tsx
@@ -1,38 +1,42 @@
 import Page from './Page';
 import PlayButton from './PlayButton';
 import Skeleton from './Skeleton';
+import { withHighlight } from './LoadingStateHighlighter';
 
-const StandardLoadingState = () => {
-  return (
-    <Page>
-      <Page.SkeletonHeader />
-      <Page.Content>
-        <Page.ActionsBar>
-          <PlayButton
-            disabled
-            variant="primary"
-            size="3.5rem"
-            playing={false}
+const StandardLoadingState = withHighlight(
+  () => {
+    return (
+      <Page>
+        <Page.SkeletonHeader />
+        <Page.Content>
+          <Page.ActionsBar>
+            <PlayButton
+              disabled
+              variant="primary"
+              size="3.5rem"
+              playing={false}
+            />
+          </Page.ActionsBar>
+          <Skeleton.Table
+            rows={10}
+            columns={[
+              <Skeleton.Text key="text" />,
+              <div key="header" className="flex gap-2 items-end">
+                <Skeleton.CoverPhoto size="2.5rem" />
+                <div className="flex flex-col flex-1 gap-2">
+                  <Skeleton.Text width="25%" fontSize="1rem" />
+                  <Skeleton.Text width="20%" fontSize="0.75rem" />
+                </div>
+              </div>,
+              <Skeleton.Text key="text2" />,
+              <Skeleton.Text key="text3" />,
+            ]}
           />
-        </Page.ActionsBar>
-        <Skeleton.Table
-          rows={10}
-          columns={[
-            <Skeleton.Text key="text" />,
-            <div key="header" className="flex gap-2 items-end">
-              <Skeleton.CoverPhoto size="2.5rem" />
-              <div className="flex flex-col flex-1 gap-2">
-                <Skeleton.Text width="25%" fontSize="1rem" />
-                <Skeleton.Text width="20%" fontSize="0.75rem" />
-              </div>
-            </div>,
-            <Skeleton.Text key="text2" />,
-            <Skeleton.Text key="text3" />,
-          ]}
-        />
-      </Page.Content>
-    </Page>
-  );
-};
+        </Page.Content>
+      </Page>
+    );
+  },
+  { shade: '#ff2600' }
+);
 
 export default StandardLoadingState;

--- a/client/src/components/Suspense.tsx
+++ b/client/src/components/Suspense.tsx
@@ -1,21 +1,13 @@
-import React, { SuspenseProps as ReactSuspenseProps } from 'react';
+import React, { SuspenseProps } from 'react';
 import LoadingStateHighlighter from './LoadingStateHighlighter';
-
-interface SuspenseProps extends ReactSuspenseProps {
-  shade?: string;
-}
 
 // A decorated <Suspense /> component that will highlight the loading state when
 // the "Highlight Suspense Boundaries" setting is enabled.
-const Suspense = ({ fallback, shade, ...props }: SuspenseProps) => {
+const Suspense = ({ fallback, ...props }: SuspenseProps) => {
   return (
     <React.Suspense
       {...props}
-      fallback={
-        <LoadingStateHighlighter shade={shade}>
-          {fallback}
-        </LoadingStateHighlighter>
-      }
+      fallback={<LoadingStateHighlighter>{fallback}</LoadingStateHighlighter>}
     />
   );
 };


### PR DESCRIPTION
Instead of configuring the `shade` on the custom `<Suspense />` component, which has the potential to confuse others, this now allows the loading state to determine its own highlight color. If none specified, then it will appear red. Also adds the ability to specify a custom classname.