### PR TITLE
Enforce typename for offsetConnectionPagination field policy

### DIFF
--- a/client/src/apollo/client.ts
+++ b/client/src/apollo/client.ts
@@ -95,16 +95,19 @@ export default new ApolloClient({
       CurrentUser: {
         keyFields: [],
         fields: {
-          albums: offsetConnectionPagination(),
+          albums: offsetConnectionPagination('SavedAlbumsConnection'),
           albumsContains: libraryContains(),
           // TODO: Figure out why this doesn't work when using with fragment
           // episodes: offsetConnectionPagination(),
           episodesContains: libraryContains(),
           followedArtists: cursorConnectionPagination(),
           showsContains: libraryContains(),
-          playlists: offsetConnectionPagination(['@connection', ['key']]),
+          playlists: offsetConnectionPagination('PlaylistConnection', [
+            '@connection',
+            ['key'],
+          ]),
           tracksContains: libraryContains(),
-          tracks: offsetConnectionPagination(),
+          tracks: offsetConnectionPagination('SavedTracksConnection'),
         },
       },
       Developer: {
@@ -148,7 +151,7 @@ export default new ApolloClient({
       },
       Playlist: {
         fields: {
-          tracks: offsetConnectionPagination(),
+          tracks: offsetConnectionPagination('PlaylistTrackConnection'),
         },
       },
       Query: {

--- a/client/src/fieldPolicies/offsetConnectionPagination.ts
+++ b/client/src/fieldPolicies/offsetConnectionPagination.ts
@@ -4,23 +4,22 @@ import { FieldPolicy, Reference } from '@apollo/client';
 type KeyArgs = FieldPolicy<unknown>['keyArgs'];
 
 interface ConnectionPagination<T> {
+  __typename: string;
   pageInfo: Partial<PageInfo>;
   edges: T[];
 }
 
 const offsetConnectionPagination = <T = Reference>(
+  typename: string,
   keyArgs: KeyArgs = false
 ): FieldPolicy<ConnectionPagination<T>> => {
   return {
     keyArgs,
-    merge(
-      existing = { pageInfo: {}, edges: [] },
-      incoming,
-      { args, mergeObjects }
-    ) {
+    merge(existing, incoming, { args, mergeObjects }) {
       const result: ConnectionPagination<T> = {
-        pageInfo: mergeObjects(existing.pageInfo, incoming.pageInfo),
-        edges: existing.edges.slice(0),
+        __typename: typename,
+        pageInfo: mergeObjects(existing?.pageInfo ?? {}, incoming.pageInfo),
+        edges: existing?.edges.slice(0) ?? [],
       };
 
       if (!incoming.edges) {


### PR DESCRIPTION
This helps prevent bugs when connection fields are in a fragment