### PR TITLE
Add optional chaining for `error.extensions`

### DIFF
--- a/client/src/components/RootErrorBoundary.tsx
+++ b/client/src/components/RootErrorBoundary.tsx
@@ -27,7 +27,7 @@ const didBecomeUnauthenticated = (error: unknown) => {
     return (
       error.networkError instanceof AuthorizationError ||
       error.graphQLErrors.some(
-        (error) => error.extensions.code === 'UNAUTHENTICATED'
+        (error) => error.extensions?.code === 'UNAUTHENTICATED'
       )
     );
   }


### PR DESCRIPTION
This caused me some problems - I had various errors where `extensions` was unset and this check crashed the whole app.