### PR TITLE
Add query preloading to artist and album routes

### DIFF
--- a/client/src/apollo/client.ts
+++ b/client/src/apollo/client.ts
@@ -3,6 +3,7 @@ import {
   InMemoryCache,
   ApolloLink,
   createHttpLink,
+  createQueryPreloader,
   from,
   split,
 } from '@apollo/client';
@@ -72,7 +73,7 @@ const httpLink = createHttpLink({
   uri: import.meta.env.VITE_SERVER_HOST,
 });
 
-export default new ApolloClient({
+const client = new ApolloClient({
   link: from([httpAuthLink, persistedQueries, httpLink]),
   connectToDevTools: true,
   name: 'Spotify Showcase Website',
@@ -170,3 +171,7 @@ export default new ApolloClient({
     },
   }),
 });
+
+export const preloadQuery = createQueryPreloader(client);
+
+export default client;

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useRef } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigation } from 'react-router-dom';
 import Layout from './Layout';
 import ScrollContainerContext from './ScrollContainerContext';
 import Playbar, { LoadingState as PlaybarLoadingState } from './Playbar';
@@ -21,8 +21,11 @@ import CurrentUserMenu, {
 import Suspense from './Suspense';
 import StandardLoadingState from './StandardLoadingState';
 import { withHighlight } from './LoadingStateHighlighter';
+import cx from 'classnames';
 
 const LoggedInLayout = () => {
+  const navigation = useNavigation();
+
   return (
     <Suspense fallback={<LoadingState />}>
       <Container>
@@ -30,7 +33,14 @@ const LoggedInLayout = () => {
         <Main>
           <Header />
           <Suspense fallback={<StandardLoadingState />}>
-            <Outlet />
+            <div
+              className={cx({
+                'opacity-30 transition-opacity duration-100':
+                  navigation.state === 'loading',
+              })}
+            >
+              <Outlet />
+            </div>
           </Suspense>
         </Main>
         <Playbar />

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -95,6 +95,7 @@ const routes = createRoutesFromElements(
         />
         <Route
           path="artists/:artistId"
+          loader={ArtistRoute.loader}
           element={
             <Suspense fallback={<ArtistRoute.LoadingState />}>
               <ArtistRoute.RouteComponent />

--- a/client/src/router.tsx
+++ b/client/src/router.tsx
@@ -87,6 +87,7 @@ const routes = createRoutesFromElements(
         />
         <Route
           path="albums/:albumId"
+          loader={AlbumRoute.loader}
           element={
             <Suspense fallback={<AlbumRoute.LoadingState />}>
               <AlbumRoute.RouteComponent />

--- a/client/src/routes/albums/album.tsx
+++ b/client/src/routes/albums/album.tsx
@@ -81,7 +81,9 @@ export const loader = ({ params }: LoaderFunctionArgs) => {
     throw new Response('', { status: 404 });
   }
 
-  return preloadQuery(ALBUM_ROUTE_QUERY, { variables: { albumId } });
+  return preloadQuery(ALBUM_ROUTE_QUERY, {
+    variables: { albumId },
+  }).toPromise();
 };
 
 export const RouteComponent = () => {

--- a/client/src/routes/albums/album.tsx
+++ b/client/src/routes/albums/album.tsx
@@ -1,5 +1,10 @@
-import { gql, useSuspenseQuery } from '@apollo/client';
-import { useParams } from 'react-router-dom';
+import {
+  TypedDocumentNode,
+  gql,
+  useReadQuery,
+  useSuspenseQuery,
+} from '@apollo/client';
+import { LoaderFunctionArgs, useLoaderData, useParams } from 'react-router-dom';
 import {
   AlbumRouteQuery,
   AlbumRouteQueryVariables,
@@ -22,8 +27,12 @@ import useSavedTracksContains from '../../hooks/useSavedTracksContains';
 import LikeButton from '../../components/LikeButton';
 import useSaveAlbumsMutation from '../../mutations/useSaveAlbumsMutation';
 import useRemoveSavedAlbumsMutation from '../../mutations/useRemoveSavedAlbumsMutation';
+import { preloadQuery } from '../../apollo/client';
 
-const ALBUM_ROUTE_QUERY = gql`
+const ALBUM_ROUTE_QUERY: TypedDocumentNode<
+  AlbumRouteQuery,
+  AlbumRouteQueryVariables
+> = gql`
   query AlbumRouteQuery($albumId: ID!) {
     me {
       albumsContains(ids: [$albumId])
@@ -65,12 +74,19 @@ const PLAYBACK_STATE_FRAGMENT = gql`
   }
 `;
 
+export const loader = ({ params }: LoaderFunctionArgs) => {
+  const { albumId } = params;
+
+  if (!albumId) {
+    throw new Response('', { status: 404 });
+  }
+
+  return preloadQuery(ALBUM_ROUTE_QUERY, { variables: { albumId } });
+};
+
 export const RouteComponent = () => {
-  const { albumId } = useParams() as { albumId: 'string' };
-  const { data } = useSuspenseQuery<AlbumRouteQuery, AlbumRouteQueryVariables>(
-    ALBUM_ROUTE_QUERY,
-    { variables: { albumId } }
-  );
+  const queryRef = useLoaderData() as Awaited<ReturnType<typeof loader>>;
+  const { data } = useReadQuery(queryRef);
 
   const [resumePlayback] = useResumePlaybackMutation();
   const [saveAlbums] = useSaveAlbumsMutation();

--- a/client/src/routes/artists/artist.tsx
+++ b/client/src/routes/artists/artist.tsx
@@ -1,6 +1,6 @@
-import { gql, useSuspenseQuery } from '@apollo/client';
+import { TypedDocumentNode, gql, useReadQuery } from '@apollo/client';
 import cx from 'classnames';
-import { useParams } from 'react-router-dom';
+import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import { Get } from 'type-fest';
 import { ArtistRouteQuery, ArtistRouteQueryVariables } from '../../types/api';
 import AlbumTile from '../../components/AlbumTile';
@@ -9,10 +9,14 @@ import ArtistTopTracks from '../../components/ArtistTopTracks';
 import Page from '../../components/Page';
 import Skeleton from '../../components/Skeleton';
 import TileGrid from '../../components/TileGrid';
+import { preloadQuery } from '../../apollo/client';
 
 type Album = NonNullable<Get<ArtistRouteQuery, 'artist.albums.edges[0].node'>>;
 
-const ARTIST_ROUTE_QUERY = gql`
+const ARTIST_ROUTE_QUERY: TypedDocumentNode<
+  ArtistRouteQuery,
+  ArtistRouteQueryVariables
+> = gql`
   query ArtistRouteQuery($artistId: ID!) {
     artist(id: $artistId) {
       id
@@ -74,15 +78,19 @@ const classNames = {
   section: 'flex flex-col gap-2',
 };
 
-export const RouteComponent = () => {
-  const { artistId } = useParams() as { artistId: string };
+export const loader = ({ params }: LoaderFunctionArgs) => {
+  const { artistId } = params;
 
-  const { data } = useSuspenseQuery<
-    ArtistRouteQuery,
-    ArtistRouteQueryVariables
-  >(ARTIST_ROUTE_QUERY, {
-    variables: { artistId },
-  });
+  if (!artistId) {
+    throw new Response('', { status: 404 });
+  }
+
+  return preloadQuery(ARTIST_ROUTE_QUERY, { variables: { artistId } });
+};
+
+export const RouteComponent = () => {
+  const queryRef = useLoaderData() as Awaited<ReturnType<typeof loader>>;
+  const { data } = useReadQuery(queryRef);
 
   const artist = data.artist;
 

--- a/client/src/routes/artists/artist.tsx
+++ b/client/src/routes/artists/artist.tsx
@@ -85,7 +85,9 @@ export const loader = ({ params }: LoaderFunctionArgs) => {
     throw new Response('', { status: 404 });
   }
 
-  return preloadQuery(ARTIST_ROUTE_QUERY, { variables: { artistId } });
+  return preloadQuery(ARTIST_ROUTE_QUERY, {
+    variables: { artistId },
+  }).toPromise();
 };
 
 export const RouteComponent = () => {


### PR DESCRIPTION
This updates both the artist and album routes to use query preloading released in 3.9. This demonstrates how preloading can be used in React Router loader functions while taking advantage of React transitions built into the router. Now anytime a transition occurs to one of the pages with a preloaded query, you get a slight dimming of the UI while the route is prepared, then the route will transition. 