### PR TITLE
Add integration with AI quiz generator

### DIFF
--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -33,6 +33,7 @@ import { fragmentRegistry } from '../apollo/fragmentRegistry';
 import Skeleton from './Skeleton';
 import LikeButton from './LikeButton';
 import { withHighlight } from './LoadingStateHighlighter';
+import SongQuiz from './SongQuiz';
 
 const EPISODE_SKIP_FORWARD_AMOUNT = 15_000;
 
@@ -122,10 +123,13 @@ const Playbar = () => {
         <Flex gap="1rem" alignItems="center">
           <CoverPhoto size="4rem" image={coverPhoto} />
           {playbackItem?.__typename === 'Track' ? (
-            <TrackPlaybackDetails
-              context={playbackState?.context ?? null}
-              track={playbackItem}
-            />
+            <>
+              <TrackPlaybackDetails
+                context={playbackState?.context ?? null}
+                track={playbackItem}
+              />
+              <SongQuiz id={playbackItem.id} />
+            </>
           ) : playbackItem?.__typename === 'Episode' ? (
             <EpisodePlaybackDetails episode={playbackItem} />
           ) : null}

--- a/client/src/components/Playbar.tsx
+++ b/client/src/components/Playbar.tsx
@@ -33,7 +33,7 @@ import { fragmentRegistry } from '../apollo/fragmentRegistry';
 import Skeleton from './Skeleton';
 import LikeButton from './LikeButton';
 import { withHighlight } from './LoadingStateHighlighter';
-import SongQuiz from './SongQuiz';
+import TrackQuiz from './TrackQuiz';
 
 const EPISODE_SKIP_FORWARD_AMOUNT = 15_000;
 
@@ -128,7 +128,7 @@ const Playbar = () => {
                 context={playbackState?.context ?? null}
                 track={playbackItem}
               />
-              <SongQuiz id={playbackItem.id} />
+              <TrackQuiz id={playbackItem.id} />
             </>
           ) : playbackItem?.__typename === 'Episode' ? (
             <EpisodePlaybackDetails episode={playbackItem} />

--- a/client/src/components/SongQuiz.tsx
+++ b/client/src/components/SongQuiz.tsx
@@ -1,0 +1,116 @@
+import * as Dialog from '@radix-ui/react-dialog';
+import Button from './Button';
+import { X, Pizza } from 'lucide-react';
+import { gql, useSuspenseQuery } from '@apollo/client';
+import { Suspense, useState } from 'react';
+import cx from 'classnames';
+
+// TypedDocumentNode<
+//   CurrentUserQuery,
+//   CurrentUserQueryVariables
+// >
+const SONG_QUIZ_QUERY = gql`
+  query SongQuiz($trackId: ID!) {
+    track(id: $trackId) {
+      quiz {
+        question
+        options {
+          answer
+          label
+        }
+        correctAnswer
+      }
+    }
+  }
+`;
+
+const SongQuiz = ({ id }: { id: string }) => {
+  return (
+    <QuizDialog id={id}>
+      <Pizza size="1.2rem" className="cursor-pointer hover:stroke-green" />
+    </QuizDialog>
+  );
+};
+
+export default SongQuiz;
+
+const QuizDialog = ({
+  id,
+  children,
+}: React.PropsWithChildren<{ id: string }>) => {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>{children}</Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="bg-surface/50 animate-fade-in fixed inset-0 [--animate-duration:200ms]" />
+        <Dialog.Content className="bg-surface animate-slide-left-fade fixed inset-2 left-1/3 rounded p-4 text-base shadow-2xl outline-0 [--animate-slide-distance:30px]">
+          <Dialog.Close asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="absolute right-4 top-4 !p-0"
+            >
+              <X size="1.5rem" />
+            </Button>
+          </Dialog.Close>
+          <div className="text-white px-4">
+            <Suspense fallback={<p>Loading...</p>}>
+              <QuizContent id={id} />
+            </Suspense>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+const QuizContent = ({ id }: { id: string }) => {
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const { data } = useSuspenseQuery(SONG_QUIZ_QUERY, {
+    variables: { trackId: id },
+  });
+
+  // @ts-ignore - I should run codegen
+  const quiz = data?.track?.quiz as any;
+
+  const handleAnswer = () => {
+    setSubmitted(true);
+  };
+
+  return (
+    <>
+      <h1>{quiz.question}</h1>
+      <ul className="mb-4">
+        {quiz.options.map((option: any) => (
+          <li key={option.answer}>
+            <label
+              className={cx('cursor-pointer', {
+                'text-green': submitted && option.answer === quiz.correctAnswer,
+                'text-[#ff2a2a]':
+                  submitted &&
+                  option.answer !== quiz.correctAnswer &&
+                  selectedAnswer === option.answer,
+              })}
+            >
+              <input
+                type="radio"
+                name="answer"
+                disabled={submitted}
+                value={option.answer}
+                checked={selectedAnswer === option.answer}
+                onChange={() => setSelectedAnswer(option.answer)}
+              />{' '}
+              {option.label}
+            </label>
+          </li>
+        ))}
+      </ul>
+
+      <Button variant="primary" onClick={handleAnswer}>
+        Submit
+      </Button>
+    </>
+  );
+};

--- a/client/src/components/TrackQuiz.tsx
+++ b/client/src/components/TrackQuiz.tsx
@@ -4,10 +4,8 @@ import { X, Pizza } from 'lucide-react';
 import {
   QueryReference,
   gql,
-  useBackgroundQuery,
   useLoadableQuery,
   useReadQuery,
-  useSuspenseQuery,
 } from '@apollo/client';
 import { Suspense, useState } from 'react';
 import cx from 'classnames';
@@ -16,8 +14,8 @@ import cx from 'classnames';
 //   CurrentUserQuery,
 //   CurrentUserQueryVariables
 // >
-const SONG_QUIZ_QUERY = gql`
-  query SongQuiz($trackId: ID!) {
+const QUIZ_QUERY = gql`
+  query TrackQuiz($trackId: ID!) {
     track(id: $trackId) {
       quiz {
         question
@@ -31,8 +29,8 @@ const SONG_QUIZ_QUERY = gql`
   }
 `;
 
-const SongQuiz = ({ id }: { id: string }) => {
-  const [loadQuiz, queryRef] = useLoadableQuery(SONG_QUIZ_QUERY);
+const TrackQuiz = ({ id }: { id: string }) => {
+  const [loadQuiz, queryRef] = useLoadableQuery(QUIZ_QUERY);
 
   return (
     <QuizDialog id={id} queryRef={queryRef}>
@@ -47,7 +45,7 @@ const SongQuiz = ({ id }: { id: string }) => {
   );
 };
 
-export default SongQuiz;
+export default TrackQuiz;
 
 const QuizDialog = ({
   id,


### PR DESCRIPTION
Note: This doesn't have to be merged in 😊

This PR adds an integration with a subgraph that uses LLMs to generate a question based on a Track. The "quiz" subgraph is has not been deployed anywhere just yet

This is how it works at the moment:

https://github.com/apollographql/spotify-showcase/assets/667029/36833435-8764-4be8-975a-6ba4be7bb7be

