### PR TITLE
Add playlist details modal

### DIFF
--- a/.graphqlrc.yml
+++ b/.graphqlrc.yml
@@ -1,0 +1,4 @@
+schema:
+  - ./client/schema.graphql
+  - ./client/src/apollo/localSchema.graphql
+documents: ./client/src/**/*.{ts,tsx}

--- a/client/src/components/ContextMenu/Action.tsx
+++ b/client/src/components/ContextMenu/Action.tsx
@@ -1,16 +1,20 @@
-import { ReactNode } from 'react';
+import { ReactNode, MouseEvent } from 'react';
 import Item from './Item';
 
 interface ActionProps {
   disabled?: boolean;
   children?: ReactNode;
   onSelect?: () => void;
+  onMouseOver?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-const Action = ({ children, disabled, onSelect }: ActionProps) => {
+const Action = ({ children, disabled, onSelect, onMouseOver }: ActionProps) => {
   return (
     <Item disabled={disabled} onSelect={onSelect}>
-      <button className="block w-full appearance-none text-left">
+      <button
+        className="block w-full appearance-none text-left"
+        onMouseOver={onMouseOver}
+      >
         {children}
       </button>
     </Item>

--- a/client/src/components/Form/Field.tsx
+++ b/client/src/components/Form/Field.tsx
@@ -2,14 +2,19 @@ import { ReactNode } from 'react';
 import cx from 'classnames';
 
 interface FieldProps {
+  className?: string;
   children?: ReactNode;
   orientation?: 'vertical' | 'horizontal';
 }
 
-const Field = ({ children, orientation = 'vertical' }: FieldProps) => {
+const Field = ({
+  className,
+  children,
+  orientation = 'vertical',
+}: FieldProps) => {
   return (
     <div
-      className={cx('flex flex-1 gap-2', {
+      className={cx('flex flex-1 gap-2', className, {
         'flex-col': orientation === 'vertical',
         'items-center justify-between': orientation === 'horizontal',
       })}

--- a/client/src/components/Form/Field.tsx
+++ b/client/src/components/Form/Field.tsx
@@ -14,7 +14,7 @@ const Field = ({
 }: FieldProps) => {
   return (
     <div
-      className={cx('flex flex-1 gap-2', className, {
+      className={cx('flex gap-2', className, {
         'flex-col': orientation === 'vertical',
         'items-center justify-between': orientation === 'horizontal',
       })}

--- a/client/src/components/Form/Form.tsx
+++ b/client/src/components/Form/Form.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { FormikContext, FormikProps, FormikValues } from 'formik';
+import MultilineTextField from './MultilineTextField';
 import Select from './Select';
 import TextField from './TextField';
 
@@ -27,6 +28,7 @@ function Form<TValues extends FormikValues>({
   );
 }
 
+Form.MultilineTextField = MultilineTextField;
 Form.Select = Select;
 Form.TextField = TextField;
 

--- a/client/src/components/Form/MultilineTextField.tsx
+++ b/client/src/components/Form/MultilineTextField.tsx
@@ -1,0 +1,57 @@
+import cx from 'classnames';
+import { useField } from 'formik';
+import { ComponentPropsWithoutRef } from 'react';
+import Field from './Field';
+
+type ForwardedTextareaProps = Omit<
+  ComponentPropsWithoutRef<'textarea'>,
+  'value'
+>;
+
+interface MultilineTextFieldProps extends ForwardedTextareaProps {
+  label?: string;
+  name: string;
+  description?: string;
+  size?: 'sm' | 'md';
+}
+
+const MultilineTextField = ({
+  className,
+  name,
+  description,
+  label,
+  size = 'md',
+  ...rest
+}: MultilineTextFieldProps) => {
+  const [field] = useField({ name });
+
+  return (
+    <Field orientation="vertical">
+      {(label || description) && (
+        <div className="flex flex-col gap-1">
+          {label && <label htmlFor={name}>{label}</label>}
+          {description && (
+            <span className="text-offwhite max-w-lg text-sm">
+              {description}
+            </span>
+          )}
+        </div>
+      )}
+      <textarea
+        {...rest}
+        {...field}
+        value={field.value ?? ''}
+        className={cx(
+          className,
+          'rounded bg-[#333] text-sm text-white disabled:cursor-not-allowed disabled:opacity-50',
+          {
+            'px-4 py-2': size === 'md',
+            'p-2': size === 'sm',
+          }
+        )}
+      />
+    </Field>
+  );
+};
+
+export default MultilineTextField;

--- a/client/src/components/Form/MultilineTextField.tsx
+++ b/client/src/components/Form/MultilineTextField.tsx
@@ -13,10 +13,12 @@ interface MultilineTextFieldProps extends ForwardedTextareaProps {
   name: string;
   description?: string;
   size?: 'sm' | 'md';
+  containerClassName?: string;
 }
 
 const MultilineTextField = ({
   className,
+  containerClassName,
   name,
   description,
   label,
@@ -26,7 +28,7 @@ const MultilineTextField = ({
   const [field] = useField({ name });
 
   return (
-    <Field orientation="vertical">
+    <Field className={containerClassName} orientation="vertical">
       {(label || description) && (
         <div className="flex flex-col gap-1">
           {label && <label htmlFor={name}>{label}</label>}

--- a/client/src/components/Form/TextField.tsx
+++ b/client/src/components/Form/TextField.tsx
@@ -35,6 +35,7 @@ type TextFieldValueByType = {
 };
 
 interface BaseTextFieldProps extends ForwardedInputProps {
+  containerClassName?: string;
   label?: string;
   name: string;
   description?: string;
@@ -77,6 +78,7 @@ const parsers: ParsersMap = {
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
   const {
     className,
+    containerClassName,
     description,
     label,
     name,
@@ -90,7 +92,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
   const [field, , { setValue }] = useField({ name, type: inputType });
 
   return (
-    <Field orientation={orientation}>
+    <Field className={containerClassName} orientation={orientation}>
       {(label || description) && (
         <div
           className={cx('flex flex-col gap-1', {

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -1,10 +1,15 @@
-import { ReactNode, useRef } from 'react';
+import { ReactNode, useRef, useState } from 'react';
 import { Outlet, useNavigation } from 'react-router-dom';
 import Layout from './Layout';
 import ScrollContainerContext from './ScrollContainerContext';
 import Playbar, { LoadingState as PlaybarLoadingState } from './Playbar';
 import PlaybackStateSubscriber from './PlaybackStateSubscriber';
-import { TypedDocumentNode, gql, useSuspenseQuery } from '@apollo/client';
+import {
+  TypedDocumentNode,
+  gql,
+  useLoadableQuery,
+  useSuspenseQuery,
+} from '@apollo/client';
 import { SidebarQuery, SidebarQueryVariables } from '../types/api';
 import PlaylistSidebarLink from './PlaylistSidebarLink';
 import { Library } from 'lucide-react';
@@ -13,6 +18,9 @@ import { thumbnail } from '../utils/image';
 import OffsetBasedPaginationObserver from './OffsetBasedPaginationObserver';
 import LikedSongsPlaylistCoverPhoto from './LikedSongsPlaylistCoverPhoto';
 import YourEpisodesPlaylistCoverPhoto from './YourEpisodesPlaylistCoverPhoto';
+import PlaylistDetailsModal, {
+  PLAYLIST_DETAILS_MODAL_QUERY,
+} from './PlaylistDetailsModal';
 import { randomBetween, range } from '../utils/common';
 import Skeleton from './Skeleton';
 import CurrentUserMenu, {
@@ -103,10 +111,17 @@ const SIDEBAR_QUERY: TypedDocumentNode<
 `;
 
 const Sidebar = () => {
+  const [isPlaylistDetailsModalOpen, setIsPlaylistDetailsModalOpen] =
+    useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const { data, fetchMore } = useSuspenseQuery(SIDEBAR_QUERY, {
     variables: { limit: 50 },
   });
+
+  const [preloadPlaylistDetails, queryRef, { reset }] = useLoadableQuery(
+    PLAYLIST_DETAILS_MODAL_QUERY,
+    { fetchPolicy: 'network-only' }
+  );
 
   const { me } = data;
 
@@ -163,6 +178,10 @@ const Sidebar = () => {
                 playlist={playlist}
                 coverPhoto={<CoverPhoto image={thumbnail(playlist.images)} />}
                 to={`/playlists/${playlist.id}`}
+                onMouseOverEdit={(playlist) =>
+                  preloadPlaylistDetails({ id: playlist.id })
+                }
+                onClickEdit={() => setIsPlaylistDetailsModalOpen(true)}
               />
             ))}
             <OffsetBasedPaginationObserver
@@ -172,6 +191,11 @@ const Sidebar = () => {
           </div>
         </ScrollContainerContext.Provider>
       </Layout.Sidebar.Section>
+      <PlaylistDetailsModal
+        queryRef={queryRef}
+        open={isPlaylistDetailsModalOpen}
+        onChange={(open) => setIsPlaylistDetailsModalOpen(open)}
+      />
     </Layout.Sidebar>
   );
 };

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -118,7 +118,7 @@ const Sidebar = () => {
     variables: { limit: 50 },
   });
 
-  const [preloadPlaylistDetails, queryRef, { reset }] = useLoadableQuery(
+  const [preloadPlaylistDetails, queryRef] = useLoadableQuery(
     PLAYLIST_DETAILS_MODAL_QUERY,
     { fetchPolicy: 'network-only' }
   );

--- a/client/src/components/Modal.tsx
+++ b/client/src/components/Modal.tsx
@@ -26,7 +26,7 @@ const Modal = ({ children, open, onChange, title }: ModalProps) => {
               </button>
             </Dialog.Close>
           </header>
-          <div className="p-6 pt-0 flex-1">{children}</div>
+          <div className="flex flex-col p-6 pt-0 flex-1">{children}</div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/client/src/components/PlaylistDetailsModal.tsx
+++ b/client/src/components/PlaylistDetailsModal.tsx
@@ -9,10 +9,12 @@ import {
   PlaylistDetailsModalQueryVariables,
 } from '../types/api';
 import Modal from './Modal';
-import { Suspense } from 'react';
+import { CSSProperties, Suspense } from 'react';
 import CoverPhoto from './CoverPhoto';
 import Form from './Form';
 import useForm from '../hooks/useForm';
+import { withHighlight } from './LoadingStateHighlighter';
+import Skeleton from './Skeleton';
 
 interface PlaylistDetailsModalProps {
   queryRef: QueryReference<PlaylistDetailsModalQuery> | null;
@@ -43,7 +45,7 @@ const PlaylistDetailsModal = ({
 }: PlaylistDetailsModalProps) => {
   return (
     <Modal open={open} onChange={onChange} title="Edit details">
-      <Suspense fallback="Loading...">
+      <Suspense fallback={<LoadingState />}>
         {queryRef && <PlaylistDetails queryRef={queryRef} />}
       </Suspense>
     </Modal>
@@ -99,5 +101,31 @@ const PlaylistDetails = ({ queryRef }: PlaylistDetailsProps) => {
     </Form>
   );
 };
+
+interface StyleProps extends CSSProperties {
+  '--skeleton-background-color'?: CSSProperties['backgroundColor'];
+}
+
+const LoadingState = withHighlight(
+  () => {
+    return (
+      <div
+        className="flex gap-4"
+        style={
+          {
+            '--skeleton-background-color': '#181818',
+          } as StyleProps
+        }
+      >
+        <Skeleton.CoverPhoto size="50%" />
+        <div className="flex flex-col gap-4 flex-1">
+          <Skeleton.Text width="100%" fontSize="1rem" />
+          <Skeleton.Text width="100%" fontSize="1rem" />
+        </div>
+      </div>
+    );
+  },
+  { shade: '#ff2600' }
+);
 
 export default PlaylistDetailsModal;

--- a/client/src/components/PlaylistDetailsModal.tsx
+++ b/client/src/components/PlaylistDetailsModal.tsx
@@ -10,6 +10,9 @@ import {
 } from '../types/api';
 import Modal from './Modal';
 import { Suspense } from 'react';
+import CoverPhoto from './CoverPhoto';
+import Form from './Form';
+import useForm from '../hooks/useForm';
 
 interface PlaylistDetailsModalProps {
   queryRef: QueryReference<PlaylistDetailsModalQuery> | null;
@@ -25,6 +28,10 @@ export const PLAYLIST_DETAILS_MODAL_QUERY: TypedDocumentNode<
     playlist(id: $id) {
       id
       name
+      description
+      images {
+        url
+      }
     }
   }
 `;
@@ -51,11 +58,46 @@ const PlaylistDetails = ({ queryRef }: PlaylistDetailsProps) => {
   const { data } = useReadQuery(queryRef);
   const { playlist } = data;
 
+  const form = useForm({
+    initialValues: { name: playlist?.name, description: playlist?.description },
+    onSubmit: () => {
+      // TODO: Implement
+    },
+  });
+
   if (!playlist) {
-    return <div>Error!</div>;
+    return (
+      <div className="flex flex-col flex-1 items-center justify-center">
+        <div className="text-3xl font-bold">404</div>
+        <div className="text-xl">Unable to find playlist</div>
+      </div>
+    );
   }
 
-  return <div>{playlist.name}</div>;
+  return (
+    <Form form={form} className="flex gap-4">
+      <CoverPhoto
+        animateIn
+        image={playlist.images[0]}
+        className="row-span-2 flex-1"
+      />
+      <div className="flex flex-col gap-4 flex-1">
+        <Form.TextField
+          name="name"
+          placeholder="Add a name"
+          label="Name"
+          autoComplete="off"
+        />
+        <Form.MultilineTextField
+          name="description"
+          placeholder="Add an optional description"
+          label="Description"
+          className="flex-1"
+          containerClassName="flex-1"
+        />
+      </div>
+    </Form>
+  );
 };
 
 export default PlaylistDetailsModal;

--- a/client/src/components/PlaylistDetailsModal.tsx
+++ b/client/src/components/PlaylistDetailsModal.tsx
@@ -1,0 +1,61 @@
+import {
+  QueryReference,
+  TypedDocumentNode,
+  gql,
+  useReadQuery,
+} from '@apollo/client';
+import {
+  PlaylistDetailsModalQuery,
+  PlaylistDetailsModalQueryVariables,
+} from '../types/api';
+import Modal from './Modal';
+import { Suspense } from 'react';
+
+interface PlaylistDetailsModalProps {
+  queryRef: QueryReference<PlaylistDetailsModalQuery> | null;
+  open: boolean;
+  onChange: (open: boolean) => void;
+}
+
+export const PLAYLIST_DETAILS_MODAL_QUERY: TypedDocumentNode<
+  PlaylistDetailsModalQuery,
+  PlaylistDetailsModalQueryVariables
+> = gql`
+  query PlaylistDetailsModalQuery($id: ID!) {
+    playlist(id: $id) {
+      id
+      name
+    }
+  }
+`;
+
+const PlaylistDetailsModal = ({
+  queryRef,
+  open,
+  onChange,
+}: PlaylistDetailsModalProps) => {
+  return (
+    <Modal open={open} onChange={onChange} title="Edit details">
+      <Suspense fallback="Loading...">
+        {queryRef && <PlaylistDetails queryRef={queryRef} />}
+      </Suspense>
+    </Modal>
+  );
+};
+
+interface PlaylistDetailsProps {
+  queryRef: QueryReference<PlaylistDetailsModalQuery>;
+}
+
+const PlaylistDetails = ({ queryRef }: PlaylistDetailsProps) => {
+  const { data } = useReadQuery(queryRef);
+  const { playlist } = data;
+
+  if (!playlist) {
+    return <div>Error!</div>;
+  }
+
+  return <div>{playlist.name}</div>;
+};
+
+export default PlaylistDetailsModal;

--- a/client/src/components/Skeleton/Base.tsx
+++ b/client/src/components/Skeleton/Base.tsx
@@ -17,7 +17,7 @@ function Base<TElement extends ElementType>({
       {...props}
       className={cx(
         className,
-        'opacity-50 bg-surface relative overflow-hidden rounded-2xl',
+        'opacity-50 [background-color:var(--skeleton-background-color,rgb(40_40_40_/_var(--tw-bg-opacity)))] relative overflow-hidden rounded-2xl',
         'after:animate-shimmer after:absolute after:inset-0 after:translate-x-[-100%]',
         'after:[background-image:linear-gradient(90deg,rgba(55,55,55,0)_0,rgba(55,55,55,0.2)_20%,rgba(55,55,55,0.5)_60%,rgba(55,55,55,0))]'
       )}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -2515,7 +2515,6 @@ export type EpisodeDetailsCell_episode = {
 
 export type EpisodePlaybackDetails_episode = {
   __typename: 'Episode';
-  id: string;
   name: string;
   show: { __typename: 'Show'; id: string; name: string };
 };
@@ -2880,6 +2879,11 @@ export type PlaylistSidebarLink_playbackState = {
   context: { __typename: 'PlaybackContext'; uri: string } | null;
 };
 
+export type PlaylistSidebarLink_currentUser = {
+  __typename: 'CurrentUser';
+  profile: { __typename: 'CurrentUserProfile'; id: string };
+};
+
 export type PlaylistSidebarLink_playlist = {
   __typename: 'Playlist';
   id: string;
@@ -2970,7 +2974,6 @@ export type TrackPlaybackDetails_context = {
 
 export type TrackPlaybackDetails_track = {
   __typename: 'Track';
-  id: string;
   name: string;
   uri: string;
   album: { __typename: 'Album'; id: string; name: string };

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -2873,6 +2873,14 @@ export type Playbar_playbackState = {
     | null;
 };
 
+export type PlaylistDetailsModalQueryVariables = Exact<{
+  id: Scalars['ID']['input'];
+}>;
+
+export type PlaylistDetailsModalQuery = {
+  playlist: { __typename: 'Playlist'; id: string; name: string } | null;
+};
+
 export type PlaylistSidebarLink_playbackState = {
   __typename: 'PlaybackState';
   isPlaying: boolean;

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -2878,7 +2878,13 @@ export type PlaylistDetailsModalQueryVariables = Exact<{
 }>;
 
 export type PlaylistDetailsModalQuery = {
-  playlist: { __typename: 'Playlist'; id: string; name: string } | null;
+  playlist: {
+    __typename: 'Playlist';
+    id: string;
+    name: string;
+    description: string | null;
+    images: Array<{ __typename: 'Image'; url: string }>;
+  } | null;
 };
 
 export type PlaylistSidebarLink_playbackState = {


### PR DESCRIPTION
Supercedes https://github.com/apollographql/spotify-showcase/pull/171

Adds a playlist details modal when clicking on the "Edit playlist" context menu action from the sidebar. This doesn't yet implement the actual save behavior yet, but is a good demo of the new `useLoadableQuery` hook.