### PR TITLE
Deprecate fields that talk to deprecated Spotify APIs

### DIFF
--- a/client/src/routes/albums/album.tsx
+++ b/client/src/routes/albums/album.tsx
@@ -1,9 +1,4 @@
-import {
-  TypedDocumentNode,
-  gql,
-  useReadQuery,
-  useSuspenseQuery,
-} from '@apollo/client';
+import { TypedDocumentNode, gql, useReadQuery } from '@apollo/client';
 import { LoaderFunctionArgs, useLoaderData, useParams } from 'react-router-dom';
 import {
   AlbumRouteQuery,

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -2380,7 +2380,11 @@ export type AlbumTrackTitleCell_playbackState = {
     | null;
 };
 
-export type AlbumTrackTitleCell_album = { __typename: 'Album'; uri: string };
+export type AlbumTrackTitleCell_album = {
+  __typename: 'Album';
+  id: string;
+  uri: string;
+};
 
 export type AlbumTrackTitleCell_track = {
   __typename: 'Track';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,7 @@ export default ts.config(
       'shared/**/*.ts',
     ],
     rules: {
-      '@typescript-eslint/no-deprecated': 'error',
+      '@typescript-eslint/no-deprecated': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
       '@typescript-eslint/no-unsafe-assignment': 'warn',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,7 @@ export default ts.config(
       'shared/**/*.ts',
     ],
     rules: {
+      '@typescript-eslint/no-deprecated': 'error',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
       '@typescript-eslint/no-unsafe-assignment': 'warn',

--- a/shared/spotify-api/src/client.ts
+++ b/shared/spotify-api/src/client.ts
@@ -614,6 +614,8 @@ export class SpotifyClient extends RESTDataSource implements SpotifyDataSource {
         return 'UNAUTHENTICATED';
       case 403:
         return 'FORBIDDEN';
+      case 404:
+        return 'NOT_FOUND';
       case 400:
         return ApolloServerErrorCode.BAD_USER_INPUT;
       default:

--- a/shared/spotify-api/src/dataSource.ts
+++ b/shared/spotify-api/src/dataSource.ts
@@ -46,6 +46,7 @@ export interface SpotifyDataSource {
     id: string,
     params?: Spotify.Request.QueryParams.GET['/artists/:id/albums']
   ): Promise<Spotify.Response.GET['/artists/:id/albums']>;
+  /** @deprecated */
   getArtistRelatedArtists(
     artistId: string
   ): Promise<Spotify.Response.GET['/artists/:id/related-artists']>;
@@ -76,6 +77,7 @@ export interface SpotifyDataSource {
     params?: Spotify.Request.QueryParams.GET['/me/player/currently-playing']
   ): Promise<Spotify.Response.GET['/me/player/currently-playing'] | null>;
   getDevices(): Promise<Spotify.Response.GET['/me/player/devices']>;
+  /** @deprecated */
   getGenres(): Promise<
     Spotify.Response.GET['/recommendations/available-genre-seeds']
   >;
@@ -89,6 +91,7 @@ export interface SpotifyDataSource {
   getShows(
     params: Spotify.Request.QueryParams.GET['/shows']
   ): Promise<Spotify.Response.GET['/shows']>;
+  /** @deprecated */
   getRecommendations(
     params: Spotify.Request.QueryParams.GET['/recommendations']
   ): Promise<Spotify.Response.GET['/recommendations']>;
@@ -111,6 +114,7 @@ export interface SpotifyDataSource {
   getCurrentUserTracks(
     params?: Spotify.Request.QueryParams.GET['/me/tracks']
   ): Promise<Spotify.Response.GET['/me/tracks']>;
+  /** @deprecated */
   getFeaturedPlaylists(
     params: Spotify.Request.QueryParams.GET['/browse/featured-playlists']
   ): Promise<Spotify.Response.GET['/browse/featured-playlists']>;
@@ -144,12 +148,14 @@ export interface SpotifyDataSource {
     id: string,
     params?: Spotify.Request.QueryParams.GET['/tracks/:id']
   ): Promise<Spotify.Object.Track | undefined>;
+  /** @deprecated */
   getTrackAudioFeatures(
     trackId: string
   ): Promise<Spotify.Response.GET['/audio-features/:id']>;
   getTracks(
     params: Spotify.Request.QueryParams.GET['/tracks']
   ): Promise<Spotify.Response.GET['/tracks']>;
+  /** @deprecated */
   getTracksAudioFeatures(
     params: Spotify.Request.QueryParams.GET['/audio-features']
   ): Promise<Spotify.Response.GET['/audio-features']>;

--- a/subgraphs/spotify/schema.graphql
+++ b/subgraphs/spotify/schema.graphql
@@ -85,6 +85,7 @@ type Query {
   [recommendations](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations).
   """
   genres: [String!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Recommendations for the current user.
@@ -126,6 +127,7 @@ type Query {
     """
     limit: Int
   ): Recommendations
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Information about the current logged-in user.
@@ -182,6 +184,7 @@ type Query {
     """
     timestamp: DateTime
   ): FeaturedPlaylistConnection
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Get Spotify catalog information about albums, artists, playlists, tracks, shows, episodes or audiobooks that match a keyword string.
@@ -270,6 +273,7 @@ type Query {
     """
     ids: [ID!]!
   ): [TrackAudioFeatures!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   user(id: ID!): User @tag(name: "internal")
 }
@@ -594,6 +598,7 @@ type Artist @key(fields: "id") {
   [listening history](http://news.spotify.com/se/2010/02/03/related-artists/).
   """
   relatedArtists: [Artist!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Spotify catalog information about an artist's top tracks.
@@ -1892,6 +1897,7 @@ type Track implements PlaylistTrack & PlaybackItem @key(fields: "id") {
   The track's audio feature information
   """
   audioFeatures: TrackAudioFeatures
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   The disc number (usually `1` unless the album consists of more than one disc).

--- a/subgraphs/spotify/src/__generated__/resolvers-types.ts
+++ b/subgraphs/spotify/src/__generated__/resolvers-types.ts
@@ -206,6 +206,7 @@ export type Artist = {
    * Spotify catalog information about artists similar to a given artist.
    * Similarity is based on analysis of the Spotify community's
    * [listening history](http://news.spotify.com/se/2010/02/03/related-artists/).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   relatedArtists: Array<Artist>;
   /** Spotify catalog information about an artist's top tracks. */
@@ -1006,11 +1007,13 @@ export type Query = {
   /**
    * A list of Spotify featured playlists (shown, for example, on a Spotify
    * player's 'Browse' tab).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   featuredPlaylists?: Maybe<FeaturedPlaylistConnection>;
   /**
    * A list of available genres seed parameter values for
    * [recommendations](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   genres: Array<Scalars['String']['output']>;
   /** Information about the current logged-in user. */
@@ -1029,6 +1032,7 @@ export type Query = {
    *
    * For artists and tracks that are very new or obscure there might not be enough
    * data to generate a list of tracks.
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   recommendations?: Maybe<Recommendations>;
   /**
@@ -1051,7 +1055,10 @@ export type Query = {
   track?: Maybe<Track>;
   /** Get Spotify catalog information for multiple tracks based on their Spotify IDs. */
   tracks?: Maybe<Array<Track>>;
-  /** Get audio features for multiple tracks based on their Spotify IDs. */
+  /**
+   * Get audio features for multiple tracks based on their Spotify IDs.
+   * @deprecated This endpoint no longer exists in the Spotify API
+   */
   tracksAudioFeatures: Array<TrackAudioFeatures>;
   user?: Maybe<User>;
 };
@@ -1785,7 +1792,10 @@ export type Track = PlaybackItem &
     album: Album;
     /** The artists who performed the track. */
     artists: Array<Artist>;
-    /** The track's audio feature information */
+    /**
+     * The track's audio feature information
+     * @deprecated This endpoint no longer exists in the Spotify API
+     */
     audioFeatures?: Maybe<TrackAudioFeatures>;
     /** The disc number (usually `1` unless the album consists of more than one disc). */
     discNumber: Scalars['Int']['output'];


### PR DESCRIPTION
Example: https://developer.spotify.com/documentation/web-api/reference/get-an-artists-related-artists

A request against this endpoint will now 404. Will follow up with a client PR soon.