### PR TITLE
Fix pages that use deprecated fields

### DIFF
--- a/client/schema.graphql
+++ b/client/schema.graphql
@@ -278,6 +278,7 @@ type Artist {
   [listening history](http://news.spotify.com/se/2010/02/03/related-artists/).
   """
   relatedArtists: [Artist!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Spotify catalog information about an artist's top tracks.
@@ -1579,6 +1580,7 @@ type Query {
   [recommendations](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations).
   """
   genres: [String!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Recommendations for the current user.
@@ -1620,6 +1622,7 @@ type Query {
     """
     limit: Int
   ): Recommendations
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Information about the current logged-in user.
@@ -1676,6 +1679,7 @@ type Query {
     """
     timestamp: DateTime
   ): FeaturedPlaylistConnection
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   Get Spotify catalog information about albums, artists, playlists, tracks, shows, episodes or audiobooks that match a keyword string.
@@ -1764,6 +1768,7 @@ type Query {
     """
     ids: [ID!]!
   ): [TrackAudioFeatures!]!
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 }
 
 type RecentlyPlayedConnection {
@@ -2768,6 +2773,7 @@ type Track implements PlaylistTrack & PlaybackItem {
   The track's audio feature information
   """
   audioFeatures: TrackAudioFeatures
+    @deprecated(reason: "This endpoint no longer exists in the Spotify API")
 
   """
   The disc number (usually `1` unless the album consists of more than one disc).

--- a/client/src/components/Layout/Sidebar.tsx
+++ b/client/src/components/Layout/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, ReactNode } from 'react';
 import { Link } from 'react-router-dom';
-import { Home, Search } from 'lucide-react';
+import { Home, Library, Search } from 'lucide-react';
 import cx from 'classnames';
 import ApolloLogo from '../ApolloLogo';
 import NavLink from './NavLink';
@@ -22,6 +22,9 @@ const Sidebar = ({ children }: SidebarProps) => {
           </NavLink>
           <NavLink icon={<Search />} to="/search">
             Search
+          </NavLink>
+          <NavLink icon={<Library />} to="/collection/playlists">
+            Library
           </NavLink>
         </Section>
         {children}

--- a/client/src/components/LikedSongsTile.tsx
+++ b/client/src/components/LikedSongsTile.tsx
@@ -106,7 +106,7 @@ const LikedSongsTile = ({
             ? undefined
             : { offset: { position: 0 }, contextUri: spotifyURI };
 
-          resumePlayback(input);
+          void resumePlayback(input);
         }}
       />
     </Link>

--- a/client/src/components/LoadingStateHighlighter.tsx
+++ b/client/src/components/LoadingStateHighlighter.tsx
@@ -2,6 +2,7 @@ import { Children, ReactNode, isValidElement } from 'react';
 import { useReactiveVar } from '@apollo/client';
 import { highlightSuspenseBoundariesVar } from '../vars';
 import LoadingStateBackdrop from './LoadingStateBackdrop';
+import React from 'react';
 
 interface LoadingStateHighlighterProps {
   children: ReactNode;
@@ -37,7 +38,7 @@ const LoadingStateHighlighter = ({
 };
 
 const isHighlighted = (
-  element: JSX.ElementType
+  element: React.JSX.ElementType
 ): element is HighlightableComponent<unknown> => {
   return typeof element !== 'string' && '__highlight' in element;
 };

--- a/client/src/components/LoggedInLayout.tsx
+++ b/client/src/components/LoggedInLayout.tsx
@@ -86,7 +86,7 @@ const SIDEBAR_QUERY: TypedDocumentNode<
 > = gql`
   query SidebarQuery($offset: Int, $limit: Int) {
     me {
-      user {
+      profile {
         id
       }
       playlists(offset: $offset, limit: $limit)
@@ -145,7 +145,7 @@ const Sidebar = () => {
                 __typename: 'Playlist',
                 id: 'collection:tracks',
                 name: 'Liked Songs',
-                uri: `spotify:user:${me.user.id}:collection`,
+                uri: `spotify:user:${me.profile.id}:collection`,
                 owner: {
                   __typename: 'User',
                   id: 'spotify',
@@ -161,7 +161,7 @@ const Sidebar = () => {
                 __typename: 'Playlist',
                 id: 'collection:episodes',
                 name: 'Your Episodes',
-                uri: `spotify:user:${me.user.id}:collection:your-episodes`,
+                uri: `spotify:user:${me.profile.id}:collection:your-episodes`,
                 owner: {
                   __typename: 'User',
                   id: 'spotify',

--- a/client/src/routes/artists/artist.tsx
+++ b/client/src/routes/artists/artist.tsx
@@ -4,7 +4,6 @@ import { LoaderFunctionArgs, useLoaderData } from 'react-router-dom';
 import { Get } from 'type-fest';
 import { ArtistRouteQuery, ArtistRouteQueryVariables } from '../../types/api';
 import AlbumTile from '../../components/AlbumTile';
-import ArtistTile from '../../components/ArtistTile';
 import ArtistTopTracks from '../../components/ArtistTopTracks';
 import Page from '../../components/Page';
 import Skeleton from '../../components/Skeleton';
@@ -38,10 +37,6 @@ const ARTIST_ROUTE_QUERY: TypedDocumentNode<
       }
       images {
         url
-      }
-      relatedArtists {
-        id
-        ...ArtistTile_artist
       }
       topTracks {
         id
@@ -126,15 +121,6 @@ export const RouteComponent = () => {
           albums={getAlbums(artist.singles)}
         />
         <AlbumSection title="Appears On" albums={getAlbums(artist.appearsOn)} />
-
-        <section className={classNames.section}>
-          <h2>Fans also like</h2>
-          <TileGrid gap="1rem" minTileWidth="200px">
-            {artist.relatedArtists.map((relatedArtist) => (
-              <ArtistTile key={relatedArtist.id} artist={relatedArtist} />
-            ))}
-          </TileGrid>
-        </section>
       </Page.Content>
     </Page>
   );

--- a/client/src/routes/collection/playlists.tsx
+++ b/client/src/routes/collection/playlists.tsx
@@ -15,7 +15,7 @@ import Skeleton from '../../components/Skeleton';
 const COLLECTION_PLAYLISTS_ROUTE_QUERY = gql`
   query CollectionPlaylistsRouteQuery($offset: Int, $limit: Int) {
     me {
-      user {
+      profile {
         id
       }
       episodes {
@@ -92,7 +92,7 @@ export const RouteComponent = () => {
   }
 
   const {
-    user: currentUser,
+    profile,
     episodes: { pageInfo: episodePageInfo },
     playlists: { pageInfo: playlistPageInfo, edges: playlistEdges },
     tracks,
@@ -107,7 +107,7 @@ export const RouteComponent = () => {
         <LikedSongsTile
           connection={tracks}
           className="col-span-2"
-          currentUser={currentUser}
+          currentUser={profile}
         />
         <MediaTile to="/collection/episodes">
           <GradientIcon

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -66,7 +66,7 @@ const PlaylistTileGrid = ({
 
   return (
     <div className={containerStyles}>
-      <PageTitle>My playlists</PageTitle>
+      <PageTitle>Saved playlists</PageTitle>
       {playlistEdges.length === 0 ? (
         <Page.EmptyState
           icon={<ListMusic />}

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -3615,7 +3615,7 @@ export type CollectionPlaylistsRouteQueryVariables = Exact<{
 export type CollectionPlaylistsRouteQuery = {
   me: {
     __typename: 'CurrentUser';
-    user: { __typename: 'User'; id: string };
+    profile: { __typename: 'CurrentUserProfile'; id: string };
     episodes: {
       __typename: 'SavedEpisodesConnection';
       pageInfo: { __typename: 'PageInfo'; total: number };

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -202,6 +202,7 @@ export type Artist = {
    * Spotify catalog information about artists similar to a given artist.
    * Similarity is based on analysis of the Spotify community's
    * [listening history](http://news.spotify.com/se/2010/02/03/related-artists/).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   relatedArtists: Array<Artist>;
   /** Spotify catalog information about an artist's top tracks. */
@@ -1086,11 +1087,13 @@ export type Query = {
   /**
    * A list of Spotify featured playlists (shown, for example, on a Spotify
    * player's 'Browse' tab).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   featuredPlaylists: Maybe<FeaturedPlaylistConnection>;
   /**
    * A list of available genres seed parameter values for
    * [recommendations](https://developer.spotify.com/documentation/web-api/reference/#/operations/get-recommendations).
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   genres: Array<Scalars['String']['output']>;
   /** Information about the current logged-in user. */
@@ -1109,6 +1112,7 @@ export type Query = {
    *
    * For artists and tracks that are very new or obscure there might not be enough
    * data to generate a list of tracks.
+   * @deprecated This endpoint no longer exists in the Spotify API
    */
   recommendations: Maybe<Recommendations>;
   /**
@@ -1131,7 +1135,10 @@ export type Query = {
   track: Maybe<Track>;
   /** Get Spotify catalog information for multiple tracks based on their Spotify IDs. */
   tracks: Maybe<Array<Track>>;
-  /** Get audio features for multiple tracks based on their Spotify IDs. */
+  /**
+   * Get audio features for multiple tracks based on their Spotify IDs.
+   * @deprecated This endpoint no longer exists in the Spotify API
+   */
   tracksAudioFeatures: Array<TrackAudioFeatures>;
 };
 
@@ -1999,7 +2006,10 @@ export type Track = PlaybackItem &
     album: Album;
     /** The artists who performed the track. */
     artists: Array<Artist>;
-    /** The track's audio feature information */
+    /**
+     * The track's audio feature information
+     * @deprecated This endpoint no longer exists in the Spotify API
+     */
     audioFeatures: Maybe<TrackAudioFeatures>;
     /** The disc number (usually `1` unless the album consists of more than one disc). */
     discNumber: Scalars['Int']['output'];

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -2593,7 +2593,7 @@ export type SidebarQueryVariables = Exact<{
 export type SidebarQuery = {
   me: {
     __typename: 'CurrentUser';
-    user: { __typename: 'User'; id: string };
+    profile: { __typename: 'CurrentUserProfile'; id: string };
     playlists: {
       __typename: 'PlaylistConnection';
       pageInfo: {

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -3850,24 +3850,26 @@ export type EpisodeRouteQuery = {
 };
 
 export type IndexRouteQueryVariables = Exact<{
-  timestamp?: InputMaybe<Scalars['DateTime']['input']>;
+  limit: Scalars['Int']['input'];
 }>;
 
 export type IndexRouteQuery = {
-  featuredPlaylists: {
-    __typename: 'FeaturedPlaylistConnection';
-    message: string;
-    edges: Array<{
-      __typename: 'FeaturedPlaylistEdge';
-      node: {
-        __typename: 'Playlist';
-        id: string;
-        name: string;
-        description: string | null;
-        uri: string;
-        images: Array<{ __typename: 'Image'; url: string }> | null;
-      };
-    }>;
+  me: {
+    __typename: 'CurrentUser';
+    playlists: {
+      __typename: 'PlaylistConnection';
+      edges: Array<{
+        __typename: 'PlaylistEdge';
+        node: {
+          __typename: 'Playlist';
+          id: string;
+          name: string;
+          description: string | null;
+          uri: string;
+          images: Array<{ __typename: 'Image'; url: string }> | null;
+        };
+      }>;
+    } | null;
   } | null;
 };
 

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -3512,12 +3512,6 @@ export type ArtistRouteQuery = {
     } | null;
     followers: { __typename: 'Followers'; total: number };
     images: Array<{ __typename: 'Image'; url: string }>;
-    relatedArtists: Array<{
-      __typename: 'Artist';
-      id: string;
-      name: string;
-      images: Array<{ __typename: 'Image'; url: string }>;
-    }>;
     topTracks: Array<{
       __typename: 'Track';
       id: string;

--- a/client/src/utils/types.ts
+++ b/client/src/utils/types.ts
@@ -5,7 +5,7 @@ import { Reference } from '@apollo/client';
 
 export type PropsOf<
   TComponent extends
-    | keyof JSX.IntrinsicElements
+    | keyof React.JSX.IntrinsicElements
     | React.JSXElementConstructor<unknown>,
 > = JSX.LibraryManagedAttributes<
   TComponent,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,6 +51,7 @@ export default ts.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      '@typescript-eslint/no-deprecated': 'error',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-misused-promises': 'warn',
       '@typescript-eslint/no-unsafe-assignment': 'warn',
@@ -134,7 +135,7 @@ export default ts.config(
           },
         },
       ],
-      '@graphql-eslint/no-deprecated': 'warn',
+      '@graphql-eslint/no-deprecated': 'error',
       '@graphql-eslint/no-unused-fragments': 'off',
     },
   }

--- a/subgraphs/spotify/src/resolvers/CurrentUser.ts
+++ b/subgraphs/spotify/src/resolvers/CurrentUser.ts
@@ -12,11 +12,17 @@ export const CurrentUser: CurrentUserResolvers = {
   albumsContains: (_, { ids }, { dataSources }) => {
     return dataSources.spotify.checkContainsAlbums(ids.join(','));
   },
-  episodes: (_, { limit, offset }, { dataSources }) => {
-    return dataSources.spotify.getCurrentUserEpisodes({
+  episodes: async (_, { limit, offset }, { dataSources }) => {
+    const paginated = await dataSources.spotify.getCurrentUserEpisodes({
       limit: maybe(limit),
       offset: maybe(offset),
     });
+
+    // TODO: Allow `null` as valid values for all fields.
+    return {
+      ...paginated,
+      items: paginated.items.filter(({ episode }) => episode.id !== null),
+    };
   },
   episodesContains: (_, { ids }, { dataSources }) => {
     return dataSources.spotify.checkContainsEpisodes(ids.join(','));


### PR DESCRIPTION
Since Spotify's API deprecated some endpoints, some of the UI no longer works since errors are returned from the graph. This updates a few pages:

- Shows the logged in user's saved playlists on the main page
- Removes the use of related artists on the artist page
- Uses `profile` field instead of `user` in areas where it was still used

This also fixes an issue where an episode could come back with all null details.