### PR TITLE
Update Vite host to comply with Spotify Redirect URI policy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
       "type": "chrome",
       "request": "launch",
       "name": "Website",
-      "url": "http://localhost:3000",
+      "url": "http://127.0.0.1:3000",
       "webRoot": "${workspaceFolder}/client",
       "outFiles": ["${workspaceFolder}/dist/*.js", "!**/node_modules/**"]
     }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ What do you want to do next with this demo app?
    npm start
    ```
 
-4. Visit the website at http://localhost:3000.
+4. Visit the website at http://127.0.0.1:3000.
 
 By default, the client app is pointing to the _locally-running_ backend URL. Follow the section below for "I want to run the backend locally" (you can choose to use Docker, or not).
 
@@ -200,7 +200,7 @@ You will need a GraphOS organization with an Enterprise plan or [Enterprise tria
 
 There are launch configurations for the client project and subgraph projects. You can navigate to the debug tab of VS Code and launch any of the projects. They will default to the following urls:
 
-- Client App - http://localhost:3000
+- Client App - http://127.0.0.1:3000
 - Spotify Subgraph - http://localhost:4001
 - Playback Subgraph - http://localhost:4002
 

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -142,7 +142,7 @@ const LoggedOut = () => {
               redirect URI for this app to allow this app to sign in to your
               Spotify account.
             </Paragraph>
-            <CodeBlock>http://localhost:3000/oauth/finalize</CodeBlock>
+            <CodeBlock>http://127.0.0.1:3000/oauth/finalize</CodeBlock>
           </ListItem>
         </OrderedList>
         <Heading level={3}>Configure this application</Heading>

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig(async (env) => {
     },
     server: {
       open: true,
+      host: '127.0.0.1',
       port: process.env.PORT ?? 3000,
     },
     plugins: [

--- a/subgraphs/playback/src/utils/env.ts
+++ b/subgraphs/playback/src/utils/env.ts
@@ -9,7 +9,7 @@ export const readEnv = (key: string, options?: ReadEnvOptions) => {
 
   invariant(
     value,
-    `\`process.env.${key}\` must be defined. To get started, visit the home page at http://localhost:3000.`
+    `\`process.env.${key}\` must be defined. To get started, visit the home page at http://127.0.0.1:3000.`
   );
 
   return value;

--- a/subgraphs/spotify/src/utils/env.ts
+++ b/subgraphs/spotify/src/utils/env.ts
@@ -9,7 +9,7 @@ export const readEnv = (key: string, options?: ReadEnvOptions) => {
 
   invariant(
     value,
-    `\`process.env.${key}\` must be defined. To get started, visit the home page at http://localhost:3000.`
+    `\`process.env.${key}\` must be defined. To get started, visit the home page at http://127.0.0.1:3000.`
   );
 
   return value;


### PR DESCRIPTION
As of 9th of April 2025 Spotify [requires](https://developer.spotify.com/documentation/web-api/concepts/redirect_uri) all Redirect URIs to be direct.
This makes running the example (out of the box) impossible unless you already have a localhost Redirect URI pre-made.


<img width="810" alt="image" src="https://github.com/user-attachments/assets/1d5bbf53-6896-4c88-a923-219b733a146e" />

<img width="786" alt="image" src="https://github.com/user-attachments/assets/009ed2ac-e15b-4b89-b757-5266593bf6e2" />



I've updated the client app to explicitly run on 127.0.0.1:3000 so it can safely be added as a Redirect URI in Shopify development portal, including references in documentation and env files.

<img width="784" alt="image" src="https://github.com/user-attachments/assets/deb1c005-c5a8-44d9-8f59-866a8ec69855" />


Let me know if you think this can cause any other problems (like perhaps CORS?) so we can think of ways to fix that. 
Cheers!